### PR TITLE
feat: update binutils to 2.41-6deepin2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+binutils (2.41-6deepin2) unstable; urgency=medium
+
+  * Enable full cross compilation set for amd64, arm64, loong64, and riscv64.
+  * Backport fixes for LoongArch from upstream (binutils-2_41-branch, master).
+  * Backport LoongArch -mthin-add-sub support from upstream (for kernel live-
+    patching).
+  * Drop ia64, ppc64 targets.
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Tue, 18 Jun 2024 10:47:01 +0800
+
 binutils (2.41-6~deepin1) unstable; urgency=medium
 
   * Build packages for loong64.

--- a/debian/control
+++ b/debian/control
@@ -275,7 +275,7 @@ Description: Common files for the GNU assembler, linker and binary utilities
 
 Package: binutils-x86-64-linux-gnu
 Priority: optional
-Architecture: amd64 arm64 i386 ppc64el x32
+Architecture: amd64 arm64 i386 ppc64el x32 arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -293,7 +293,7 @@ Description: GNU binary utilities, for x86-64-linux-gnu target
 Package: binutils-x86-64-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: amd64 arm64 i386 ppc64el x32
+Architecture: amd64 arm64 i386 ppc64el x32 arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-x86-64-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for x86-64-linux-gnu target (debug symbols)
@@ -301,7 +301,7 @@ Description: GNU binary utilities, for x86-64-linux-gnu target (debug symbols)
 
 Package: binutils-i686-linux-gnu
 Priority: optional
-Architecture: i386 amd64 arm64 ppc64el x32
+Architecture: i386 amd64 arm64 ppc64el x32 arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -319,7 +319,7 @@ Description: GNU binary utilities, for i686-linux-gnu target
 Package: binutils-i686-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: i386 amd64 arm64 ppc64el x32
+Architecture: i386 amd64 arm64 ppc64el x32 arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-i686-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for i686-linux-gnu target (debug symbols)
@@ -327,7 +327,7 @@ Description: GNU binary utilities, for i686-linux-gnu target (debug symbols)
 
 Package: binutils-aarch64-linux-gnu
 Priority: optional
-Architecture: arm64 amd64 i386 x32 ppc64el
+Architecture: arm64 amd64 i386 x32 ppc64el loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -345,7 +345,7 @@ Description: GNU binary utilities, for aarch64-linux-gnu target
 Package: binutils-aarch64-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: arm64 amd64 i386 x32 ppc64el
+Architecture: arm64 amd64 i386 x32 ppc64el loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-aarch64-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for aarch64-linux-gnu target (debug symbols)
@@ -353,7 +353,7 @@ Description: GNU binary utilities, for aarch64-linux-gnu target (debug symbols)
 
 Package: binutils-arm-linux-gnueabihf
 Priority: optional
-Architecture: armhf amd64 i386 x32 arm64 ppc64el
+Architecture: armhf amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -371,7 +371,7 @@ Description: GNU binary utilities, for arm-linux-gnueabihf target
 Package: binutils-arm-linux-gnueabihf-dbg
 Section: debug
 Priority: optional
-Architecture: armhf amd64 i386 x32 arm64 ppc64el
+Architecture: armhf amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-arm-linux-gnueabihf (= ${binary:Version})
 Description: GNU binary utilities, for arm-linux-gnueabihf target (debug symbols)
@@ -379,7 +379,7 @@ Description: GNU binary utilities, for arm-linux-gnueabihf target (debug symbols
 
 Package: binutils-arm-linux-gnueabi
 Priority: optional
-Architecture: armel amd64 i386 x32 arm64 ppc64el
+Architecture: armel amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -397,7 +397,7 @@ Description: GNU binary utilities, for arm-linux-gnueabi target
 Package: binutils-arm-linux-gnueabi-dbg
 Section: debug
 Priority: optional
-Architecture: armel amd64 i386 x32 arm64 ppc64el
+Architecture: armel amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-arm-linux-gnueabi (= ${binary:Version})
 Description: GNU binary utilities, for arm-linux-gnueabi target (debug symbols)
@@ -405,7 +405,7 @@ Description: GNU binary utilities, for arm-linux-gnueabi target (debug symbols)
 
 Package: binutils-powerpc64le-linux-gnu
 Priority: optional
-Architecture: ppc64el amd64 i386 x32 ppc64 arm64
+Architecture: ppc64el amd64 i386 x32 arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -423,7 +423,7 @@ Description: GNU binary utilities, for powerpc64le-linux-gnu target
 Package: binutils-powerpc64le-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: ppc64el amd64 i386 x32 ppc64 arm64
+Architecture: ppc64el amd64 i386 x32 arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-powerpc64le-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for powerpc64le-linux-gnu target (debug symbols)
@@ -431,7 +431,7 @@ Description: GNU binary utilities, for powerpc64le-linux-gnu target (debug symbo
 
 Package: binutils-s390x-linux-gnu
 Priority: optional
-Architecture: s390x amd64 i386 x32 arm64 ppc64el
+Architecture: s390x amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -449,7 +449,7 @@ Description: GNU binary utilities, for s390x-linux-gnu target
 Package: binutils-s390x-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: s390x amd64 i386 x32 arm64 ppc64el
+Architecture: s390x amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-s390x-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for s390x-linux-gnu target (debug symbols)
@@ -457,7 +457,7 @@ Description: GNU binary utilities, for s390x-linux-gnu target (debug symbols)
 
 Package: binutils-arc-linux-gnu
 Priority: optional
-Architecture: arc amd64 i386 x32 arm64 ppc64el
+Architecture: arc amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -475,7 +475,7 @@ Description: GNU binary utilities, for arc-linux-gnu target
 Package: binutils-arc-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: arc amd64 i386 x32 arm64 ppc64el
+Architecture: arc amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-arc-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for arc-linux-gnu target (debug symbols)
@@ -483,7 +483,7 @@ Description: GNU binary utilities, for arc-linux-gnu target (debug symbols)
 
 Package: binutils-hppa-linux-gnu
 Priority: optional
-Architecture: hppa amd64 i386 x32 arm64 ppc64el
+Architecture: hppa amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -501,41 +501,15 @@ Description: GNU binary utilities, for hppa-linux-gnu target
 Package: binutils-hppa-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: hppa amd64 i386 x32 arm64 ppc64el
+Architecture: hppa amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-hppa-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for hppa-linux-gnu target (debug symbols)
  This package provides debug symbols for binutils-hppa-linux-gnu.
 
-Package: binutils-ia64-linux-gnu
-Priority: optional
-Architecture: ia64 amd64 i386 x32
-Multi-Arch: allowed
-Depends: binutils-common (= ${binary:Version}),
-  ${shlibs:Depends}, ${extraDepends}
-Suggests: binutils-doc (= ${source:Version})
-Provides: 
-Breaks: binutils (<< 2.29-6), binutils-dev (<< 2.38.50.20220609-2)
-Replaces: binutils (<< 2.29-6), binutils-dev (<< 2.38.50.20220609-2)
-Description: GNU binary utilities, for ia64-linux-gnu target
- This package provides GNU assembler, linker and binary utilities
- for the ia64-linux-gnu target.
- .
- You don't need this package unless you plan to cross-compile programs
- for ia64-linux-gnu and ia64-linux-gnu is not your native platform.
-
-Package: binutils-ia64-linux-gnu-dbg
-Section: debug
-Priority: optional
-Architecture: ia64 amd64 i386 x32
-Multi-Arch: foreign
-Depends: binutils-ia64-linux-gnu (= ${binary:Version})
-Description: GNU binary utilities, for ia64-linux-gnu target (debug symbols)
- This package provides debug symbols for binutils-ia64-linux-gnu.
-
 Package: binutils-loongarch64-linux-gnu
 Priority: optional
-Architecture: loong64 amd64 i386 x32 arm64 ppc64el
+Architecture: loong64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -553,7 +527,7 @@ Description: GNU binary utilities, for loongarch64-linux-gnu target
 Package: binutils-loongarch64-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: loong64 amd64 i386 x32 arm64 ppc64el
+Architecture: loong64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-loongarch64-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for loongarch64-linux-gnu target (debug symbols)
@@ -561,7 +535,7 @@ Description: GNU binary utilities, for loongarch64-linux-gnu target (debug symbo
 
 Package: binutils-m68k-linux-gnu
 Priority: optional
-Architecture: m68k amd64 i386 x32 arm64 ppc64el
+Architecture: m68k amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -579,7 +553,7 @@ Description: GNU binary utilities, for m68k-linux-gnu target
 Package: binutils-m68k-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: m68k amd64 i386 x32 arm64 ppc64el
+Architecture: m68k amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-m68k-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for m68k-linux-gnu target (debug symbols)
@@ -587,7 +561,7 @@ Description: GNU binary utilities, for m68k-linux-gnu target (debug symbols)
 
 Package: binutils-powerpc-linux-gnu
 Priority: optional
-Architecture: powerpc amd64 i386 x32 arm64 ppc64el
+Architecture: powerpc amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -605,41 +579,15 @@ Description: GNU binary utilities, for powerpc-linux-gnu target
 Package: binutils-powerpc-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: powerpc amd64 i386 x32 arm64 ppc64el
+Architecture: powerpc amd64 i386 x32 arm64 ppc64el loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-powerpc-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for powerpc-linux-gnu target (debug symbols)
  This package provides debug symbols for binutils-powerpc-linux-gnu.
 
-Package: binutils-powerpc64-linux-gnu
-Priority: optional
-Architecture: ppc64 amd64 i386 x32 ppc64el
-Multi-Arch: allowed
-Depends: binutils-common (= ${binary:Version}),
-  ${shlibs:Depends}, ${extraDepends}
-Suggests: binutils-doc (= ${source:Version})
-Provides: 
-Breaks: binutils (<< 2.29-6), binutils-dev (<< 2.38.50.20220609-2)
-Replaces: binutils (<< 2.29-6), binutils-dev (<< 2.38.50.20220609-2)
-Description: GNU binary utilities, for powerpc64-linux-gnu target
- This package provides GNU assembler, linker and binary utilities
- for the powerpc64-linux-gnu target.
- .
- You don't need this package unless you plan to cross-compile programs
- for powerpc64-linux-gnu and powerpc64-linux-gnu is not your native platform.
-
-Package: binutils-powerpc64-linux-gnu-dbg
-Section: debug
-Priority: optional
-Architecture: ppc64 amd64 i386 x32 ppc64el
-Multi-Arch: foreign
-Depends: binutils-powerpc64-linux-gnu (= ${binary:Version})
-Description: GNU binary utilities, for powerpc64-linux-gnu target (debug symbols)
- This package provides debug symbols for binutils-powerpc64-linux-gnu.
-
 Package: binutils-riscv64-linux-gnu
 Priority: optional
-Architecture: riscv64 amd64 i386 x32 arm64 ppc64el
+Architecture: riscv64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -657,7 +605,7 @@ Description: GNU binary utilities, for riscv64-linux-gnu target
 Package: binutils-riscv64-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: riscv64 amd64 i386 x32 arm64 ppc64el
+Architecture: riscv64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-riscv64-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for riscv64-linux-gnu target (debug symbols)
@@ -665,7 +613,7 @@ Description: GNU binary utilities, for riscv64-linux-gnu target (debug symbols)
 
 Package: binutils-sh4-linux-gnu
 Priority: optional
-Architecture: sh4 amd64 i386 x32 arm64 ppc64el
+Architecture: sh4 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -683,7 +631,7 @@ Description: GNU binary utilities, for sh4-linux-gnu target
 Package: binutils-sh4-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: sh4 amd64 i386 x32 arm64 ppc64el
+Architecture: sh4 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-sh4-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for sh4-linux-gnu target (debug symbols)
@@ -691,7 +639,7 @@ Description: GNU binary utilities, for sh4-linux-gnu target (debug symbols)
 
 Package: binutils-sparc64-linux-gnu
 Priority: optional
-Architecture: sparc64 amd64 i386 x32 arm64 ppc64el
+Architecture: sparc64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -709,7 +657,7 @@ Description: GNU binary utilities, for sparc64-linux-gnu target
 Package: binutils-sparc64-linux-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: sparc64 amd64 i386 x32 arm64 ppc64el
+Architecture: sparc64 amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-sparc64-linux-gnu (= ${binary:Version})
 Description: GNU binary utilities, for sparc64-linux-gnu target (debug symbols)
@@ -717,7 +665,7 @@ Description: GNU binary utilities, for sparc64-linux-gnu target (debug symbols)
 
 Package: binutils-x86-64-linux-gnux32
 Priority: optional
-Architecture: x32 amd64 arm64 i386 ppc64el
+Architecture: x32 amd64 arm64 i386 ppc64el arm64 loong64 riscv64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -735,7 +683,7 @@ Description: GNU binary utilities, for x86-64-linux-gnux32 target
 Package: binutils-x86-64-linux-gnux32-dbg
 Section: debug
 Priority: optional
-Architecture: x32 amd64 arm64 i386 ppc64el
+Architecture: x32 amd64 arm64 i386 ppc64el arm64 loong64 riscv64
 Multi-Arch: foreign
 Depends: binutils-x86-64-linux-gnux32 (= ${binary:Version})
 Description: GNU binary utilities, for x86-64-linux-gnux32 target (debug symbols)
@@ -743,7 +691,7 @@ Description: GNU binary utilities, for x86-64-linux-gnux32 target (debug symbols
 
 Package: binutils-x86-64-gnu
 Priority: optional
-Architecture: hurd-amd64 amd64 i386 x32
+Architecture: hurd-amd64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -761,7 +709,7 @@ Description: GNU binary utilities, for x86-64-gnu target
 Package: binutils-x86-64-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: hurd-amd64 amd64 i386 x32
+Architecture: hurd-amd64
 Multi-Arch: foreign
 Depends: binutils-x86-64-gnu (= ${binary:Version})
 Description: GNU binary utilities, for x86-64-gnu target (debug symbols)
@@ -769,7 +717,7 @@ Description: GNU binary utilities, for x86-64-gnu target (debug symbols)
 
 Package: binutils-i686-gnu
 Priority: optional
-Architecture: hurd-i386 amd64 i386 x32
+Architecture: hurd-i386
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -787,7 +735,7 @@ Description: GNU binary utilities, for i686-gnu target
 Package: binutils-i686-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: hurd-i386 amd64 i386 x32
+Architecture: hurd-i386
 Multi-Arch: foreign
 Depends: binutils-i686-gnu (= ${binary:Version})
 Description: GNU binary utilities, for i686-gnu target (debug symbols)
@@ -795,7 +743,7 @@ Description: GNU binary utilities, for i686-gnu target (debug symbols)
 
 Package: binutils-x86-64-kfreebsd-gnu
 Priority: optional
-Architecture: kfreebsd-amd64 amd64 i386 x32
+Architecture: kfreebsd-amd64
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -813,7 +761,7 @@ Description: GNU binary utilities, for x86-64-kfreebsd-gnu target
 Package: binutils-x86-64-kfreebsd-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: kfreebsd-amd64 amd64 i386 x32
+Architecture: kfreebsd-amd64
 Multi-Arch: foreign
 Depends: binutils-x86-64-kfreebsd-gnu (= ${binary:Version})
 Description: GNU binary utilities, for x86-64-kfreebsd-gnu target (debug symbols)
@@ -821,7 +769,7 @@ Description: GNU binary utilities, for x86-64-kfreebsd-gnu target (debug symbols
 
 Package: binutils-i686-kfreebsd-gnu
 Priority: optional
-Architecture: kfreebsd-i386 amd64 i386 x32
+Architecture: kfreebsd-i386
 Multi-Arch: allowed
 Depends: binutils-common (= ${binary:Version}),
   ${shlibs:Depends}, ${extraDepends}
@@ -839,7 +787,7 @@ Description: GNU binary utilities, for i686-kfreebsd-gnu target
 Package: binutils-i686-kfreebsd-gnu-dbg
 Section: debug
 Priority: optional
-Architecture: kfreebsd-i386 amd64 i386 x32
+Architecture: kfreebsd-i386
 Multi-Arch: foreign
 Depends: binutils-i686-kfreebsd-gnu (= ${binary:Version})
 Description: GNU binary utilities, for i686-kfreebsd-gnu target (debug symbols)

--- a/debian/patches/0001-LoongArch-Fix-ld-no-relax-bug.patch
+++ b/debian/patches/0001-LoongArch-Fix-ld-no-relax-bug.patch
@@ -1,0 +1,56 @@
+From 350ed2029d1e461f3f76199bc119943655ec9a19 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:11 +0800
+Subject: [PATCH 01/12] LoongArch: Fix ld --no-relax bug
+
+When calling ld with --no-relax, pcalau12i + ld.d still can be relaxed.
+This patch fix this bug and pcalau12i + ld.d can be relaxed with --relax.
+
+(cherry picked from commit 363174776d13db9f35f2e54d8f7f5e34b64acbee)
+---
+ bfd/elfnn-loongarch.c | 19 ++++++-------------
+ 1 file changed, 6 insertions(+), 13 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index e9c408b2dff..d46e52191cb 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -3996,29 +3996,22 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	    loongarch_relax_align (abfd, sec, sym_sec, info, rel, symval);
+ 	  break;
+ 	case R_LARCH_DELETE:
+-	  if (info->relax_pass == 1)
++	  if (1 == info->relax_pass)
+ 	    {
+ 	      loongarch_relax_delete_bytes (abfd, sec, rel->r_offset, 4, info);
+ 	      rel->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
+ 	    }
+ 	  break;
+ 	case R_LARCH_PCALA_HI20:
+-	  if (info->relax_pass == 0)
+-	    {
+-	      if (i + 4 > sec->reloc_count)
+-		break;
+-	      loongarch_relax_pcala_addi (abfd, sec, rel, symval);
+-	    }
++	  if (0 == info->relax_pass && (i + 4) <= sec->reloc_count)
++	    loongarch_relax_pcala_addi (abfd, sec, rel, symval);
+ 	  break;
+ 	case R_LARCH_GOT_PC_HI20:
+-	  if (local_got)
++	  if (local_got && 0 == info->relax_pass
++	      && (i + 4) <= sec->reloc_count)
+ 	    {
+-	      if (i + 4 > sec->reloc_count)
+-		break;
+ 	      if (loongarch_relax_pcala_ld (abfd, sec, rel))
+-		{
+-		  loongarch_relax_pcala_addi (abfd, sec, rel, symval);
+-		}
++		loongarch_relax_pcala_addi (abfd, sec, rel, symval);
+ 	    }
+ 	  break;
+ 	default:
+-- 
+2.43.4
+

--- a/debian/patches/0002-LoongArch-Directly-delete-relaxed-instuctions-in-fir.patch
+++ b/debian/patches/0002-LoongArch-Directly-delete-relaxed-instuctions-in-fir.patch
@@ -1,0 +1,60 @@
+From b7a7f4aa5567cac9db017eff0b572f9d40223f46 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:12 +0800
+Subject: [PATCH 02/12] LoongArch: Directly delete relaxed instuctions in first
+ relaxation pass
+
+Directly delete relaxed instuctions in first relaxation pass, not use
+R_LARCH_DELETE relocation. If not, the PC-relative offset may increase.
+
+(cherry picked from commit 4e94082d95e046f357409cd689ffeedd60f6c673)
+---
+ bfd/elfnn-loongarch.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index d46e52191cb..d7b4dba230a 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -3739,7 +3739,8 @@ loongarch_relax_delete_bytes (bfd *abfd,
+ /* Relax pcalau12i,addi.d => pcaddi.  */
+ static bool
+ loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
+-		       Elf_Internal_Rela *rel_hi, bfd_vma symval)
++		       Elf_Internal_Rela *rel_hi, bfd_vma symval,
++		       struct bfd_link_info *info)
+ {
+   bfd_byte *contents = elf_section_data (sec)->this_hdr.contents;
+   Elf_Internal_Rela *rel_lo = rel_hi + 2;
+@@ -3771,8 +3772,9 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
+   /* Adjust relocations.  */
+   rel_hi->r_info = ELFNN_R_INFO (ELFNN_R_SYM (rel_hi->r_info),
+ 				 R_LARCH_PCREL20_S2);
+-  rel_lo->r_info = ELFNN_R_INFO (ELFNN_R_SYM (rel_hi->r_info),
+-				 R_LARCH_DELETE);
++  rel_lo->r_info = ELFNN_R_INFO (0, R_LARCH_NONE);
++
++  loongarch_relax_delete_bytes (abfd, sec, rel_lo->r_offset, 4, info);
+ 
+   return true;
+ }
+@@ -4004,14 +4006,14 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	  break;
+ 	case R_LARCH_PCALA_HI20:
+ 	  if (0 == info->relax_pass && (i + 4) <= sec->reloc_count)
+-	    loongarch_relax_pcala_addi (abfd, sec, rel, symval);
++	    loongarch_relax_pcala_addi (abfd, sec, rel, symval, info);
+ 	  break;
+ 	case R_LARCH_GOT_PC_HI20:
+ 	  if (local_got && 0 == info->relax_pass
+ 	      && (i + 4) <= sec->reloc_count)
+ 	    {
+ 	      if (loongarch_relax_pcala_ld (abfd, sec, rel))
+-		loongarch_relax_pcala_addi (abfd, sec, rel, symval);
++		loongarch_relax_pcala_addi (abfd, sec, rel, symval, info);
+ 	    }
+ 	  break;
+ 	default:
+-- 
+2.43.4
+

--- a/debian/patches/0003-LoongArch-Multiple-relax_trip-in-one-relax_pass.patch
+++ b/debian/patches/0003-LoongArch-Multiple-relax_trip-in-one-relax_pass.patch
@@ -1,0 +1,57 @@
+From dbcf9dc5e4b76787647ef83ea62709a4710605a5 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:13 +0800
+Subject: [PATCH 03/12] LoongArch: Multiple relax_trip in one relax_pass
+
+If deleting instructions in one relax_trip, set again to true to start the
+next relax_trip.
+
+(cherry picked from commit b130a0849a1b3e174210903cf5370092decc62d6)
+---
+ bfd/elfnn-loongarch.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index d7b4dba230a..95240fdb395 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -3740,7 +3740,7 @@ loongarch_relax_delete_bytes (bfd *abfd,
+ static bool
+ loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
+ 		       Elf_Internal_Rela *rel_hi, bfd_vma symval,
+-		       struct bfd_link_info *info)
++		       struct bfd_link_info *info, bool *again)
+ {
+   bfd_byte *contents = elf_section_data (sec)->this_hdr.contents;
+   Elf_Internal_Rela *rel_lo = rel_hi + 2;
+@@ -3766,6 +3766,9 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
+       || ((bfd_signed_vma)(symval - pc) > (bfd_signed_vma)(int32_t)0x1ffffc))
+     return false;
+ 
++  /* Continue next relax trip.  */
++  *again = true;
++
+   pca = pcaddi | rd;
+   bfd_put (32, abfd, pca, contents + rel_hi->r_offset);
+ 
+@@ -4006,14 +4009,15 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	  break;
+ 	case R_LARCH_PCALA_HI20:
+ 	  if (0 == info->relax_pass && (i + 4) <= sec->reloc_count)
+-	    loongarch_relax_pcala_addi (abfd, sec, rel, symval, info);
++	    loongarch_relax_pcala_addi (abfd, sec, rel, symval, info, again);
+ 	  break;
+ 	case R_LARCH_GOT_PC_HI20:
+ 	  if (local_got && 0 == info->relax_pass
+ 	      && (i + 4) <= sec->reloc_count)
+ 	    {
+ 	      if (loongarch_relax_pcala_ld (abfd, sec, rel))
+-		loongarch_relax_pcala_addi (abfd, sec, rel, symval, info);
++		loongarch_relax_pcala_addi (abfd, sec, rel, symval,
++					    info, again);
+ 	    }
+ 	  break;
+ 	default:
+-- 
+2.43.4
+

--- a/debian/patches/0004-LoongArch-Remove-elf_seg_map-info-output_bfd-NULL-re.patch
+++ b/debian/patches/0004-LoongArch-Remove-elf_seg_map-info-output_bfd-NULL-re.patch
@@ -1,0 +1,112 @@
+From 17809bca7a0e2e5245fb342cfebe3bc6c695f2d4 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:14 +0800
+Subject: [PATCH 04/12] LoongArch: Remove "elf_seg_map (info->output_bfd) ==
+ NULL" relaxation condition
+
+Previously the condition prevented shared objects from being relaxed.
+To remove the limitation, we need to update program header size and
+.eh_frame_hdr size before relaxation.
+
+(cherry picked from commit 4f2469d0cdd0f3bd1d9040521e002e8df0a63a98)
+---
+ bfd/elfnn-loongarch.c        | 25 +++++++++++++++++++++----
+ ld/emultempl/loongarchelf.em | 18 ++++++++++++++++++
+ 2 files changed, 39 insertions(+), 4 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index 95240fdb395..4aea9765109 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -3738,7 +3738,7 @@ loongarch_relax_delete_bytes (bfd *abfd,
+ 
+ /* Relax pcalau12i,addi.d => pcaddi.  */
+ static bool
+-loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
++loongarch_relax_pcala_addi (bfd *abfd, asection *sec, asection *sym_sec,
+ 		       Elf_Internal_Rela *rel_hi, bfd_vma symval,
+ 		       struct bfd_link_info *info, bool *again)
+ {
+@@ -3747,7 +3747,24 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec,
+   uint32_t pca = bfd_get (32, abfd, contents + rel_hi->r_offset);
+   uint32_t add = bfd_get (32, abfd, contents + rel_lo->r_offset);
+   uint32_t rd = pca & 0x1f;
++
++  /* This section's output_offset need to subtract the bytes of instructions
++     relaxed by the previous sections, so it needs to be updated beforehand.
++     size_input_section already took care of updating it after relaxation,
++     so we additionally update once here.  */
++  sec->output_offset = sec->output_section->size;
+   bfd_vma pc = sec_addr (sec) + rel_hi->r_offset;
++
++  /* If pc and symbol not in the same segment, add/sub segment alignment.
++     FIXME: if there are multiple readonly segments?  */
++  if (!(sym_sec->flags & SEC_READONLY))
++    {
++      if (symval > pc)
++	pc -= info->maxpagesize;
++      else if (symval < pc)
++	pc += info->maxpagesize;
++    }
++
+   const uint32_t addi_d = 0x02c00000;
+   const uint32_t pcaddi = 0x18000000;
+ 
+@@ -3889,7 +3906,6 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+       || sec->sec_flg0
+       || (sec->flags & SEC_RELOC) == 0
+       || sec->reloc_count == 0
+-      || elf_seg_map (info->output_bfd) == NULL
+       || (info->disable_target_specific_optimizations
+ 	  && info->relax_pass == 0)
+       /* The exp_seg_relro_adjust is enum phase_enum (0x4),
+@@ -4009,14 +4025,15 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+ 	  break;
+ 	case R_LARCH_PCALA_HI20:
+ 	  if (0 == info->relax_pass && (i + 4) <= sec->reloc_count)
+-	    loongarch_relax_pcala_addi (abfd, sec, rel, symval, info, again);
++	    loongarch_relax_pcala_addi (abfd, sec, sym_sec, rel, symval,
++					info, again);
+ 	  break;
+ 	case R_LARCH_GOT_PC_HI20:
+ 	  if (local_got && 0 == info->relax_pass
+ 	      && (i + 4) <= sec->reloc_count)
+ 	    {
+ 	      if (loongarch_relax_pcala_ld (abfd, sec, rel))
+-		loongarch_relax_pcala_addi (abfd, sec, rel, symval,
++		loongarch_relax_pcala_addi (abfd, sec, sym_sec, rel, symval,
+ 					    info, again);
+ 	    }
+ 	  break;
+diff --git a/ld/emultempl/loongarchelf.em b/ld/emultempl/loongarchelf.em
+index 4850feb8767..d81c99da48b 100644
+--- a/ld/emultempl/loongarchelf.em
++++ b/ld/emultempl/loongarchelf.em
+@@ -62,6 +62,24 @@ gld${EMULATION_NAME}_after_allocation (void)
+ 	}
+     }
+ 
++  /* The program header size of executable file may increase.  */
++  if (bfd_get_flavour (link_info.output_bfd) == bfd_target_elf_flavour
++      && !bfd_link_relocatable (&link_info))
++    {
++      if (lang_phdr_list == NULL)
++        elf_seg_map (link_info.output_bfd) = NULL;
++      if (!_bfd_elf_map_sections_to_segments (link_info.output_bfd,
++					      &link_info,
++					      NULL))
++        einfo (_("%F%P: map sections to segments failed: %E\n"));
++    }
++
++  /* Adjust program header size and .eh_frame_hdr size before
++     lang_relax_sections. Without it, the vma of data segment may increase.  */
++  lang_do_assignments (lang_allocating_phase_enum);
++  lang_reset_memory_regions ();
++  lang_size_sections (NULL, true);
++
+   enum phase_enum *phase = &(expld.dataseg.phase);
+   bfd_elf${ELFSIZE}_loongarch_set_data_segment_info (&link_info, (int *) phase);
+   /* gld${EMULATION_NAME}_map_segments (need_layout); */
+-- 
+2.43.4
+

--- a/debian/patches/0005-LoongArch-Modify-link_info.relax_pass-from-3-to-2.patch
+++ b/debian/patches/0005-LoongArch-Modify-link_info.relax_pass-from-3-to-2.patch
@@ -1,0 +1,43 @@
+From 9d22c1339aa47e0186092c2b7c2cfb82be642bb1 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:15 +0800
+Subject: [PATCH 05/12] LoongArch: Modify link_info.relax_pass from 3 to 2
+
+The first pass handles R_LARCH_RELAX relocations, the second pass
+handles R_LARCH_ALIGN relocations.
+
+(cherry picked from commit 8338aecd231af48483e36c93c103db1da715ac74)
+---
+ bfd/elfnn-loongarch.c        | 2 +-
+ ld/emultempl/loongarchelf.em | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index 4aea9765109..db9f106a8b0 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -4013,7 +4013,7 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+       switch (ELFNN_R_TYPE (rel->r_info))
+ 	{
+ 	case R_LARCH_ALIGN:
+-	  if (2 == info->relax_pass)
++	  if (1 == info->relax_pass)
+ 	    loongarch_relax_align (abfd, sec, sym_sec, info, rel, symval);
+ 	  break;
+ 	case R_LARCH_DELETE:
+diff --git a/ld/emultempl/loongarchelf.em b/ld/emultempl/loongarchelf.em
+index d81c99da48b..9974989489c 100644
+--- a/ld/emultempl/loongarchelf.em
++++ b/ld/emultempl/loongarchelf.em
+@@ -42,7 +42,7 @@ larch_elf_before_allocation (void)
+ 	ENABLE_RELAXATION;
+     }
+ 
+-  link_info.relax_pass = 3;
++  link_info.relax_pass = 2;
+ }
+ 
+ static void
+-- 
+2.43.4
+

--- a/debian/patches/0006-LoongArch-Add-more-relaxation-testcases.patch
+++ b/debian/patches/0006-LoongArch-Add-more-relaxation-testcases.patch
@@ -1,0 +1,182 @@
+From 6e7e5e47298872086bf25a637ea645809becc662 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Thu, 16 Nov 2023 19:19:16 +0800
+Subject: [PATCH 06/12] LoongArch: Add more relaxation testcases
+
+1. .so relaxation testcase
+2. ld --no-relax testcase
+3. segment alignment testcase
+
+(cherry picked from commit 580a53dab47c9e4f97c8559440d2bc43fb7331b6)
+---
+ .../ld-loongarch-elf/relax-segment-max.s      | 12 +++
+ .../ld-loongarch-elf/relax-segment-min.s      | 12 +++
+ ld/testsuite/ld-loongarch-elf/relax-so.s      |  4 +
+ ld/testsuite/ld-loongarch-elf/relax.exp       | 80 +++++++++++++++++--
+ 4 files changed, 103 insertions(+), 5 deletions(-)
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-segment-max.s
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-segment-min.s
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-so.s
+
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-segment-max.s b/ld/testsuite/ld-loongarch-elf/relax-segment-max.s
+new file mode 100644
+index 00000000000..df15d4cab09
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-segment-max.s
+@@ -0,0 +1,12 @@
++# The .align may cause overflow because deleting nops.
++  .text		      # 0x120004000
++  .align 3
++  la.local $r12, .L1
++
++#  .fill 0x1f7ffc # max fill without overflow, .data address is 0x120200000
++#  .fill 0x1f8000 # min fill with overflow, .data address is 0x120204000
++  .fill 0x1fbff4 # max fill with overflow, .data address is 0x120204000
++
++  .data
++.L1:
++  .byte 2
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-segment-min.s b/ld/testsuite/ld-loongarch-elf/relax-segment-min.s
+new file mode 100644
+index 00000000000..476b9fba78c
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-segment-min.s
+@@ -0,0 +1,12 @@
++# The .align may cause overflow because deleting nops.
++  .text		      # 0x120004000
++  .align 3
++  la.local $r12, .L1
++
++#  .fill 0x1f7ffc # max fill without overflow, .data address is 0x120200000
++  .fill 0x1f8000 # min fill with overflow, .data address is 0x120204000
++#  .fill 0x1fbff4 # max fill with overflow, .data address is 0x120204000
++
++  .data
++.L1:
++  .byte 2
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-so.s b/ld/testsuite/ld-loongarch-elf/relax-so.s
+new file mode 100644
+index 00000000000..01a404a8b47
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-so.s
+@@ -0,0 +1,4 @@
++.text
++.align 2
++.L1:
++  la.local $r12, .L1
+diff --git a/ld/testsuite/ld-loongarch-elf/relax.exp b/ld/testsuite/ld-loongarch-elf/relax.exp
+index 7ff876d7914..24d79ed5c20 100644
+--- a/ld/testsuite/ld-loongarch-elf/relax.exp
++++ b/ld/testsuite/ld-loongarch-elf/relax.exp
+@@ -22,7 +22,7 @@
+ if [istarget loongarch64-*-*] {
+ 
+   if [isbuild loongarch64-*-*] {
+-    set testname "loongarch relax build"
++    set testname "loongarch relax .exe build"
+     set pre_builds [list \
+       [list \
+ 	"$testname" \
+@@ -39,17 +39,87 @@ if [istarget loongarch64-*-*] {
+     if [file exist "tmpdir/relax"] {
+       set objdump_output [run_host_cmd "objdump" "-d tmpdir/relax"]
+       if { [ regexp ".*pcaddi.*pcaddi.*" $objdump_output] } {
+-	pass "loongarch relax"
++	pass "loongarch relax .exe"
+       } {
+-	fail "loongarch relax"
++	fail "loongarch relax .exe"
+       }
+     }
++
++    set testname "loongarch ld --no-relax build"
++    set pre_builds [list \
++      [list \
++	"$testname" \
++	"-Wl,--no-relax" \
++	"" \
++	{relax.s} \
++	{} \
++	"norelax" \
++      ] \
++    ]
++
++    run_cc_link_tests $pre_builds
++
++    if [file exist "tmpdir/norelax"] {
++      set objdump_output [run_host_cmd "objdump" "-d tmpdir/norelax"]
++      if { [ regexp ".*pcaddi.*" $objdump_output] } {
++	fail "loongarch ld --no-relax"
++      } {
++	pass "loongarch ld --no-relax"
++      }
++    }
++
++    run_ld_link_tests \
++	[list \
++	    [list \
++		"loongarch relax .so build" \
++		"-shared -e 0x0" "" \
++		"" \
++		{relax-so.s} \
++		{} \
++		"relax-so" \
++	    ] \
++	]
++
++      if [file exist "tmpdir/relax-so"] {
++	set objdump_output [run_host_cmd "objdump" "-d tmpdir/relax-so"]
++	if { [ regexp ".*pcaddi.*" $objdump_output] } {
++	  pass "loongarch relax .so"
++	} {
++	  fail "loongarch relax .so"
++	}
++      }
++
++    # If symbol in data segment, offset need to sub segment align to prevent
++    # overflow.
++    run_ld_link_tests \
++	[list \
++	    [list \
++		"loongarch relax segment alignment min" \
++		"-e0 -Ttext 0x120004000 -pie -z relro" "" \
++		"" \
++		{relax-segment-min.s} \
++		{} \
++		"relax-segment-min" \
++	    ] \
++	]
++
++    run_ld_link_tests \
++	[list \
++	    [list \
++		"loongarch relax segment alignment max" \
++		"-e0 -Ttext 0x120004000 -pie -z relro" "" \
++		"" \
++		{relax-segment-max.s} \
++		{} \
++		"relax-segment-max" \
++	    ] \
++	]
+   }
+ 
+   run_ld_link_tests \
+       [list \
+ 	  [list \
+-	      "relax-align" \
++	      "loongarch relax-align" \
+ 	      "-e 0x0 -z relro" "" \
+ 	      "" \
+ 	      {relax-align.s} \
+@@ -64,7 +134,7 @@ if [istarget loongarch64-*-*] {
+   run_ld_link_tests \
+       [list \
+ 	  [list \
+-	      "uleb128" \
++	      "loongarch uleb128" \
+ 	      "-e 0x0" "" \
+ 	      "" \
+ 	      {uleb128.s} \
+-- 
+2.43.4
+

--- a/debian/patches/0007-LoongArch-fix-internal-error-when-as-handling-unsupp.patch
+++ b/debian/patches/0007-LoongArch-fix-internal-error-when-as-handling-unsupp.patch
@@ -1,0 +1,77 @@
+From 9a87358c660e1a36699e981539c6eb6254114367 Mon Sep 17 00:00:00 2001
+From: Lulu Cai <cailulu@loongson.cn>
+Date: Wed, 15 Nov 2023 19:20:53 +0800
+Subject: [PATCH 07/12] LoongArch: fix internal error when as handling
+ unsupported modifier.
+
+---
+ bfd/elfxx-loongarch.c                    | 3 ---
+ gas/config/loongarch-parse.y             | 6 +++++-
+ gas/testsuite/gas/loongarch/reloc_type.d | 3 +++
+ gas/testsuite/gas/loongarch/reloc_type.l | 2 ++
+ gas/testsuite/gas/loongarch/reloc_type.s | 3 +++
+ 5 files changed, 13 insertions(+), 4 deletions(-)
+ create mode 100644 gas/testsuite/gas/loongarch/reloc_type.d
+ create mode 100644 gas/testsuite/gas/loongarch/reloc_type.l
+ create mode 100644 gas/testsuite/gas/loongarch/reloc_type.s
+
+diff --git a/bfd/elfxx-loongarch.c b/bfd/elfxx-loongarch.c
+index 2d299050c12..35676eadac7 100644
+--- a/bfd/elfxx-loongarch.c
++++ b/bfd/elfxx-loongarch.c
+@@ -1629,9 +1629,6 @@ loongarch_larch_reloc_name_lookup (bfd *abfd ATTRIBUTE_UNUSED,
+ 	return lht->bfd_type;
+     }
+ 
+-  (*_bfd_error_handler) (_("%pB: unsupported relocation type name %s"),
+-			 abfd, l_r_name);
+-  bfd_set_error (bfd_error_bad_value);
+   return BFD_RELOC_NONE;
+ }
+ 
+diff --git a/gas/config/loongarch-parse.y b/gas/config/loongarch-parse.y
+index f4e1a63b972..f786fdaee5f 100644
+--- a/gas/config/loongarch-parse.y
++++ b/gas/config/loongarch-parse.y
+@@ -132,7 +132,11 @@ reloc (const char *op_c_str, const char *id_c_str, offsetT addend)
+   if (0 == strcmp (op_c_str, "plt"))
+     btype = BFD_RELOC_LARCH_B26;
+   else
+-    btype = loongarch_larch_reloc_name_lookup (NULL, op_c_str);
++    {
++      btype = loongarch_larch_reloc_name_lookup (NULL, op_c_str);
++      if (btype == BFD_RELOC_NONE)
++	as_fatal (_("unsupported modifier %s"), op_c_str);
++    }
+ 
+   if (id_c_str)
+   {
+diff --git a/gas/testsuite/gas/loongarch/reloc_type.d b/gas/testsuite/gas/loongarch/reloc_type.d
+new file mode 100644
+index 00000000000..0a8f77825a0
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/reloc_type.d
+@@ -0,0 +1,3 @@
++#as:
++#source: reloc_type.s
++#error_output: reloc_type.l
+diff --git a/gas/testsuite/gas/loongarch/reloc_type.l b/gas/testsuite/gas/loongarch/reloc_type.l
+new file mode 100644
+index 00000000000..e981f6f2aa5
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/reloc_type.l
+@@ -0,0 +1,2 @@
++.*Assembler messages:
++.*Fatal error: unsupported modifier (.*)$
+diff --git a/gas/testsuite/gas/loongarch/reloc_type.s b/gas/testsuite/gas/loongarch/reloc_type.s
+new file mode 100644
+index 00000000000..2ce277779db
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/reloc_type.s
+@@ -0,0 +1,3 @@
++.L1:
++  nop
++  addi.d $a0,$a1,%reloc(x)
+-- 
+2.43.4
+

--- a/debian/patches/0008-as-Add-new-atomic-instructions-in-LoongArch-v1.1.patch
+++ b/debian/patches/0008-as-Add-new-atomic-instructions-in-LoongArch-v1.1.patch
@@ -1,0 +1,198 @@
+From 50c0626cbcc083cf2dd35e717733af0aae932da5 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 26 Oct 2023 17:35:13 +0800
+Subject: [PATCH 08/12] as: Add new atomic instructions in LoongArch v1.1
+
+LoongArch V1.1 release is out at
+https://github.com/loongson/LoongArch-Documentation.
+
+New atomic instructions in LoongArch v1.1:
+
+- sc.q
+- llacq.w/d
+- screl.w/d
+- amcas{_db}.b/h/w/d
+- amswap{_db}.b/h
+- amadd{_db}.b/h
+
+Signed-off-by: Jiajie Chen <c@jia.je>
+---
+ gas/config/tc-loongarch.c                   |  6 ++-
+ gas/testsuite/gas/loongarch/load_store_op.d | 42 +++++++++++++++++++++
+ gas/testsuite/gas/loongarch/load_store_op.s | 42 +++++++++++++++++++++
+ opcodes/loongarch-opc.c                     | 42 +++++++++++++++++++++
+ 4 files changed, 130 insertions(+), 2 deletions(-)
+
+diff --git a/gas/config/tc-loongarch.c b/gas/config/tc-loongarch.c
+index 2e8a259d147..29a14e7402e 100644
+--- a/gas/config/tc-loongarch.c
++++ b/gas/config/tc-loongarch.c
+@@ -882,8 +882,10 @@ check_this_insn_before_appending (struct loongarch_cl_insn *ip)
+       ip->reloc_num++;
+     }
+   else if (ip->insn->mask == 0xffff8000
+-	   /* amswap.w  rd, rk, rj  */
+-	   && ((ip->insn_bin & 0xfff00000) == 0x38600000
++	   /* amcas.b  rd, rk, rj  */
++	   && ((ip->insn_bin & 0xfff80000) == 0x38580000
++	       /* amswap.w  rd, rk, rj  */
++	       || (ip->insn_bin & 0xfff00000) == 0x38600000
+ 	       /* ammax_db.wu  rd, rk, rj  */
+ 	       || (ip->insn_bin & 0xffff0000) == 0x38700000
+ 	       /* ammin_db.wu  rd, rk, rj  */
+diff --git a/gas/testsuite/gas/loongarch/load_store_op.d b/gas/testsuite/gas/loongarch/load_store_op.d
+index e1b4dea1851..0ad83167bbc 100644
+--- a/gas/testsuite/gas/loongarch/load_store_op.d
++++ b/gas/testsuite/gas/loongarch/load_store_op.d
+@@ -176,3 +176,45 @@ Disassembly of section .text:
+  298:[ 	]+387e98a4 [ 	]+stle.h[ 	]+[ 	]+\$a0, \$a1, \$a2
+  29c:[ 	]+387f18a4 [ 	]+stle.w[ 	]+[ 	]+\$a0, \$a1, \$a2
+  2a0:[ 	]+387f98a4 [ 	]+stle.d[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2a4:[ 	]+385714c4 [ 	]+sc.q[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2a8:[ 	]+385714c4 [ 	]+sc.q[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2ac:[ 	]+385780a4 [ 	]+llacq.w[ 	]+[ 	]+\$a0, \$a1
++ 2b0:[ 	]+385780a4 [ 	]+llacq.w[ 	]+[ 	]+\$a0, \$a1
++ 2b4:[ 	]+385784a4 [ 	]+screl.w[ 	]+[ 	]+\$a0, \$a1
++ 2b8:[ 	]+385784a4 [ 	]+screl.w[ 	]+[ 	]+\$a0, \$a1
++ 2bc:[ 	]+385788a4 [ 	]+llacq.d[ 	]+[ 	]+\$a0, \$a1
++ 2c0:[ 	]+385788a4 [ 	]+llacq.d[ 	]+[ 	]+\$a0, \$a1
++ 2c4:[ 	]+38578ca4 [ 	]+screl.d[ 	]+[ 	]+\$a0, \$a1
++ 2c8:[ 	]+38578ca4 [ 	]+screl.d[ 	]+[ 	]+\$a0, \$a1
++ 2cc:[ 	]+385814c4 [ 	]+amcas.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2d0:[ 	]+385818a4 [ 	]+amcas.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2d4:[ 	]+385894c4 [ 	]+amcas.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2d8:[ 	]+385898a4 [ 	]+amcas.h[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2dc:[ 	]+385914c4 [ 	]+amcas.w[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2e0:[ 	]+385918a4 [ 	]+amcas.w[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2e4:[ 	]+385994c4 [ 	]+amcas.d[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2e8:[ 	]+385998a4 [ 	]+amcas.d[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2ec:[ 	]+385a14c4 [ 	]+amcas_db.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2f0:[ 	]+385a18a4 [ 	]+amcas_db.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2f4:[ 	]+385a94c4 [ 	]+amcas_db.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 2f8:[ 	]+385a98a4 [ 	]+amcas_db.h[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 2fc:[ 	]+385b14c4 [ 	]+amcas_db.w[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 300:[ 	]+385b18a4 [ 	]+amcas_db.w[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 304:[ 	]+385b94c4 [ 	]+amcas_db.d[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 308:[ 	]+385b98a4 [ 	]+amcas_db.d[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 30c:[ 	]+385c14c4 [ 	]+amswap.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 310:[ 	]+385c18a4 [ 	]+amswap.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 314:[ 	]+385c94c4 [ 	]+amswap.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 318:[ 	]+385c98a4 [ 	]+amswap.h[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 31c:[ 	]+385d14c4 [ 	]+amadd.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 320:[ 	]+385d18a4 [ 	]+amadd.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 324:[ 	]+385d94c4 [ 	]+amadd.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 328:[ 	]+385d98a4 [ 	]+amadd.h[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 32c:[ 	]+385e14c4 [ 	]+amswap_db.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 330:[ 	]+385e18a4 [ 	]+amswap_db.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 334:[ 	]+385e94c4 [ 	]+amswap_db.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 338:[ 	]+385e98a4 [ 	]+amswap_db.h[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 33c:[ 	]+385f14c4 [ 	]+amadd_db.b[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 340:[ 	]+385f18a4 [ 	]+amadd_db.b[ 	]+[ 	]+\$a0, \$a2, \$a1
++ 344:[ 	]+385f94c4 [ 	]+amadd_db.h[ 	]+[ 	]+\$a0, \$a1, \$a2
++ 348:[ 	]+385f98a4 [ 	]+amadd_db.h[ 	]+[ 	]+\$a0, \$a2, \$a1
+diff --git a/gas/testsuite/gas/loongarch/load_store_op.s b/gas/testsuite/gas/loongarch/load_store_op.s
+index efbd124a29c..7912adb1090 100644
+--- a/gas/testsuite/gas/loongarch/load_store_op.s
++++ b/gas/testsuite/gas/loongarch/load_store_op.s
+@@ -167,3 +167,45 @@ stle.b  $r4,$r5,$r6
+ stle.h  $r4,$r5,$r6
+ stle.w  $r4,$r5,$r6
+ stle.d  $r4,$r5,$r6
++sc.q  $r4,$r5,$r6,0
++sc.q  $r4,$r5,$r6
++llacq.w  $r4,$r5,0
++llacq.w  $r4,$r5
++screl.w  $r4,$r5,0
++screl.w  $r4,$r5
++llacq.d  $r4,$r5,0
++llacq.d  $r4,$r5
++screl.d  $r4,$r5,0
++screl.d  $r4,$r5
++amcas.b  $r4,$r5,$r6,0
++amcas.b  $r4,$r6,$r5
++amcas.h  $r4,$r5,$r6,0
++amcas.h  $r4,$r6,$r5
++amcas.w  $r4,$r5,$r6,0
++amcas.w  $r4,$r6,$r5
++amcas.d  $r4,$r5,$r6,0
++amcas.d  $r4,$r6,$r5
++amcas_db.b  $r4,$r5,$r6,0
++amcas_db.b  $r4,$r6,$r5
++amcas_db.h  $r4,$r5,$r6,0
++amcas_db.h  $r4,$r6,$r5
++amcas_db.w  $r4,$r5,$r6,0
++amcas_db.w  $r4,$r6,$r5
++amcas_db.d  $r4,$r5,$r6,0
++amcas_db.d  $r4,$r6,$r5
++amswap.b  $r4,$r5,$r6,0
++amswap.b  $r4,$r6,$r5
++amswap.h  $r4,$r5,$r6,0
++amswap.h  $r4,$r6,$r5
++amadd.b  $r4,$r5,$r6,0
++amadd.b  $r4,$r6,$r5
++amadd.h  $r4,$r5,$r6,0
++amadd.h  $r4,$r6,$r5
++amswap_db.b  $r4,$r5,$r6,0
++amswap_db.b  $r4,$r6,$r5
++amswap_db.h  $r4,$r5,$r6,0
++amswap_db.h  $r4,$r6,$r5
++amadd_db.b  $r4,$r5,$r6,0
++amadd_db.b  $r4,$r6,$r5
++amadd_db.h  $r4,$r5,$r6,0
++amadd_db.h  $r4,$r6,$r5
+diff --git a/opcodes/loongarch-opc.c b/opcodes/loongarch-opc.c
+index 2f02e33dbec..14bf475e9a6 100644
+--- a/opcodes/loongarch-opc.c
++++ b/opcodes/loongarch-opc.c
+@@ -816,6 +816,48 @@ static struct loongarch_opcode loongarch_load_store_opcodes[] =
+   { 0x38240000, 0xffff8000,	"ldx.hu",	"r0:5,r5:5,r10:5",		0,			0,	0,	0 },
+   { 0x38280000, 0xffff8000,	"ldx.wu",	"r0:5,r5:5,r10:5",		0,			0,	0,	0 },
+   { 0x382c0000, 0xffff8000,	"preldx",	"u0:5,r5:5,r10:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"sc.q",		"r,r,r,u0:0",			"sc.q %1,%2,%3",	0,	0,	0 },
++  { 0x38570000, 0xffff8000,	"sc.q",		"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"llacq.w",	"r,r,u0:0",			"llacq.w %1,%2",	0,	0,	0 },
++  { 0x38578000, 0xfffffc00,	"llacq.w",	"r0:5,r5:5",			0,			0,	0,	0 },
++  { 0x0,	0x0,		"screl.w",	"r,r,u0:0",			"screl.w %1,%2",	0,	0,	0 },
++  { 0x38578400, 0xfffffc00,	"screl.w",	"r0:5,r5:5",			0,			0,	0,	0 },
++  { 0x0,	0x0,		"llacq.d",	"r,r,u0:0",			"llacq.d %1,%2",	0,	0,	0 },
++  { 0x38578800, 0xfffffc00,	"llacq.d",	"r0:5,r5:5",			0,			0,	0,	0 },
++  { 0x0,	0x0,		"screl.d",	"r,r,u0:0",			"screl.d %1,%2",	0,	0,	0 },
++  { 0x38578c00, 0xfffffc00,	"screl.d",	"r0:5,r5:5",			0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas.b",	"r,r,r,u0:0",			"amcas.b %1,%2,%3",	0,	0,	0 },
++  { 0x38580000, 0xffff8000,	"amcas.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas.h",	"r,r,r,u0:0",			"amcas.h %1,%2,%3",	0,	0,	0 },
++  { 0x38588000, 0xffff8000,	"amcas.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas.w",	"r,r,r,u0:0",			"amcas.w %1,%2,%3",	0,	0,	0 },
++  { 0x38590000, 0xffff8000,	"amcas.w",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas.d",	"r,r,r,u0:0",			"amcas.d %1,%2,%3",	0,	0,	0 },
++  { 0x38598000, 0xffff8000,	"amcas.d",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas_db.b",	"r,r,r,u0:0",			"amcas_db.b %1,%2,%3",	0,	0,	0 },
++  { 0x385a0000, 0xffff8000,	"amcas_db.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas_db.h",	"r,r,r,u0:0",			"amcas_db.h %1,%2,%3",	0,	0,	0 },
++  { 0x385a8000, 0xffff8000,	"amcas_db.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas_db.w",	"r,r,r,u0:0",			"amcas_db.w %1,%2,%3",	0,	0,	0 },
++  { 0x385b0000, 0xffff8000,	"amcas_db.w",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amcas_db.d",	"r,r,r,u0:0",			"amcas_db.d %1,%2,%3",	0,	0,	0 },
++  { 0x385b8000, 0xffff8000,	"amcas_db.d",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amswap.b",	"r,r,r,u0:0",			"amswap.b %1,%2,%3",	0,	0,	0 },
++  { 0x385c0000, 0xffff8000,	"amswap.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amswap.h",	"r,r,r,u0:0",			"amswap.h %1,%2,%3",	0,	0,	0 },
++  { 0x385c8000, 0xffff8000,	"amswap.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amadd.b",	"r,r,r,u0:0",			"amadd.b %1,%2,%3",	0,	0,	0 },
++  { 0x385d0000, 0xffff8000,	"amadd.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amadd.h",	"r,r,r,u0:0",			"amadd.h %1,%2,%3",	0,	0,	0 },
++  { 0x385d8000, 0xffff8000,	"amadd.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amswap_db.b",	"r,r,r,u0:0",			"amswap_db.b %1,%2,%3",	0,	0,	0 },
++  { 0x385e0000, 0xffff8000,	"amswap_db.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amswap_db.h",	"r,r,r,u0:0",			"amswap_db.h %1,%2,%3",	0,	0,	0 },
++  { 0x385e8000, 0xffff8000,	"amswap_db.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amadd_db.b",	"r,r,r,u0:0",			"amadd_db.b %1,%2,%3",	0,	0,	0 },
++  { 0x385f0000, 0xffff8000,	"amadd_db.b",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
++  { 0x0,	0x0,		"amadd_db.h",	"r,r,r,u0:0",			"amadd_db.h %1,%2,%3",	0,	0,	0 },
++  { 0x385f8000, 0xffff8000,	"amadd_db.h",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
+   { 0x0,	0x0,		"amswap.w",	"r,r,r,u0:0",			"amswap.w %1,%2,%3",	0,	0,	0 },
+   { 0x38600000, 0xffff8000,	"amswap.w",	"r0:5,r10:5,r5:5",		0,			0,	0,	0 },
+   { 0x0,	0x0,		"amswap.d",	"r,r,r,u0:0",			"amswap.d %1,%2,%3",	0,	0,	0 },
+-- 
+2.43.4
+

--- a/debian/patches/0009-as-Add-new-estimated-reciprocal-instructions-in-Loon.patch
+++ b/debian/patches/0009-as-Add-new-estimated-reciprocal-instructions-in-Loon.patch
@@ -1,0 +1,127 @@
+From 2b758d47b976b5bec0bc93c95767b9022365fe3a Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Thu, 26 Oct 2023 17:35:14 +0800
+Subject: [PATCH 09/12] as: Add new estimated reciprocal instructions in
+ LoongArch v1.1
+
+New estimated reciprocal instructions in LoongArch v1.1:
+
+- frecipe.s/d
+- frsqrte.s/d
+- vfrecipe.s/d
+- vfrsqrte.s/d
+- xvfrecipe.s/d
+- xvfrsqrte.s/d
+
+Signed-off-by: Jiajie Chen <c@jia.je>
+---
+ gas/testsuite/gas/loongarch/float_op.d |  4 ++++
+ gas/testsuite/gas/loongarch/float_op.s |  4 ++++
+ gas/testsuite/gas/loongarch/vector.d   |  8 ++++++++
+ gas/testsuite/gas/loongarch/vector.s   |  8 ++++++++
+ opcodes/loongarch-opc.c                | 12 ++++++++++++
+ 5 files changed, 36 insertions(+)
+
+diff --git a/gas/testsuite/gas/loongarch/float_op.d b/gas/testsuite/gas/loongarch/float_op.d
+index f9d3b89e4a0..b09e7ba0f21 100644
+--- a/gas/testsuite/gas/loongarch/float_op.d
++++ b/gas/testsuite/gas/loongarch/float_op.d
+@@ -83,3 +83,7 @@ Disassembly of section .text:
+ [ 	]+124:[ 	]+011d2820 [ 	]+ffint.d.l[ 	]+[ 	]+\$fa0, \$fa1
+ [ 	]+128:[ 	]+011e4420 [ 	]+frint.s[ 	]+[ 	]+\$fa0, \$fa1
+ [ 	]+12c:[ 	]+011e4820 [ 	]+frint.d[ 	]+[ 	]+\$fa0, \$fa1
++[ 	]+130:[ 	]+01147420 [ 	]+frecipe.s[ 	]+[ 	]+\$fa0, \$fa1
++[ 	]+134:[ 	]+01147820 [ 	]+frecipe.d[ 	]+[ 	]+\$fa0, \$fa1
++[ 	]+138:[ 	]+01148420 [ 	]+frsqrte.s[ 	]+[ 	]+\$fa0, \$fa1
++[ 	]+13c:[ 	]+01148820 [ 	]+frsqrte.d[ 	]+[ 	]+\$fa0, \$fa1
+diff --git a/gas/testsuite/gas/loongarch/float_op.s b/gas/testsuite/gas/loongarch/float_op.s
+index 2e3ec5b8519..a83be3e3e48 100644
+--- a/gas/testsuite/gas/loongarch/float_op.s
++++ b/gas/testsuite/gas/loongarch/float_op.s
+@@ -74,3 +74,7 @@ ffint.d.w  $f0,$f1
+ ffint.d.l  $f0,$f1
+ frint.s  $f0,$f1
+ frint.d  $f0,$f1
++frecipe.s  $f0,$f1
++frecipe.d  $f0,$f1
++frsqrte.s  $f0,$f1
++frsqrte.d  $f0,$f1
+diff --git a/gas/testsuite/gas/loongarch/vector.d b/gas/testsuite/gas/loongarch/vector.d
+index 1a092bca3b8..4526b3d3640 100644
+--- a/gas/testsuite/gas/loongarch/vector.d
++++ b/gas/testsuite/gas/loongarch/vector.d
+@@ -1459,3 +1459,11 @@ Disassembly of section .text:
+ [ 	]+16a0:[ 	]+77e40420[ 	]+xvpermi.w[ 	]+\$xr0,[ 	]+\$xr1,[ 	]+0x1
+ [ 	]+16a4:[ 	]+77e80420[ 	]+xvpermi.d[ 	]+\$xr0,[ 	]+\$xr1,[ 	]+0x1
+ [ 	]+16a8:[ 	]+77ec0420[ 	]+xvpermi.q[ 	]+\$xr0,[ 	]+\$xr1,[ 	]+0x1
++[ 	]+16ac:[ 	]+729d1420[ 	]+vfrecipe.s[ 	]+\$vr0,[ 	]+\$vr1
++[ 	]+16b0:[ 	]+729d1820[ 	]+vfrecipe.d[ 	]+\$vr0,[ 	]+\$vr1
++[ 	]+16b4:[ 	]+729d2420[ 	]+vfrsqrte.s[ 	]+\$vr0,[ 	]+\$vr1
++[ 	]+16b8:[ 	]+729d2820[ 	]+vfrsqrte.d[ 	]+\$vr0,[ 	]+\$vr1
++[ 	]+16bc:[ 	]+769d1420[ 	]+xvfrecipe.s[ 	]+\$xr0,[ 	]+\$xr1
++[ 	]+16c0:[ 	]+769d1820[ 	]+xvfrecipe.d[ 	]+\$xr0,[ 	]+\$xr1
++[ 	]+16c4:[ 	]+769d2420[ 	]+xvfrsqrte.s[ 	]+\$xr0,[ 	]+\$xr1
++[ 	]+16c8:[ 	]+769d2820[ 	]+xvfrsqrte.d[ 	]+\$xr0,[ 	]+\$xr1
+diff --git a/gas/testsuite/gas/loongarch/vector.s b/gas/testsuite/gas/loongarch/vector.s
+index fe0369e763e..0283a4b4d53 100644
+--- a/gas/testsuite/gas/loongarch/vector.s
++++ b/gas/testsuite/gas/loongarch/vector.s
+@@ -1449,3 +1449,11 @@ xvldi	$xr0, 1
+ xvpermi.w	$xr0, $xr1, 1
+ xvpermi.d	$xr0, $xr1, 1
+ xvpermi.q	$xr0, $xr1, 1
++vfrecipe.s	$vr0, $vr1
++vfrecipe.d	$vr0, $vr1
++vfrsqrte.s	$vr0, $vr1
++vfrsqrte.d	$vr0, $vr1
++xvfrecipe.s	$xr0, $xr1
++xvfrecipe.d	$xr0, $xr1
++xvfrsqrte.s	$xr0, $xr1
++xvfrsqrte.d	$xr0, $xr1
+diff --git a/opcodes/loongarch-opc.c b/opcodes/loongarch-opc.c
+index 14bf475e9a6..4a88c4d775c 100644
+--- a/opcodes/loongarch-opc.c
++++ b/opcodes/loongarch-opc.c
+@@ -482,6 +482,8 @@ static struct loongarch_opcode loongarch_single_float_opcodes[] =
+   { 0x01144400, 0xfffffc00,	"fsqrt.s",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01145400, 0xfffffc00,	"frecip.s",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01146400, 0xfffffc00,	"frsqrt.s",	"f0:5,f5:5",			0,			0,	0,	0 },
++  { 0x01147400, 0xfffffc00,	"frecipe.s",	"f0:5,f5:5",			0,			0,	0,	0 },
++  { 0x01148400, 0xfffffc00,	"frsqrte.s",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01149400, 0xfffffc00,	"fmov.s",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x0114a400, 0xfffffc00,	"movgr2fr.w",	"f0:5,r5:5",			0,			0,	0,	0 },
+   { 0x0114ac00, 0xfffffc00,	"movgr2frh.w",	"f0:5,r5:5",			0,			0,	0,	0 },
+@@ -528,6 +530,8 @@ static struct loongarch_opcode loongarch_double_float_opcodes[] =
+   { 0x01144800, 0xfffffc00,	"fsqrt.d",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01145800, 0xfffffc00,	"frecip.d",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01146800, 0xfffffc00,	"frsqrt.d",	"f0:5,f5:5",			0,			0,	0,	0 },
++  { 0x01147800, 0xfffffc00,	"frecipe.d",	"f0:5,f5:5",			0,			0,	0,	0 },
++  { 0x01148800, 0xfffffc00,	"frsqrte.d",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x01149800, 0xfffffc00,	"fmov.d",	"f0:5,f5:5",			0,			0,	0,	0 },
+   { 0x0114a800, 0xfffffc00,	"movgr2fr.d",	"f0:5,r5:5",			0,			0,	0,	0 },
+   { 0x0114b800, 0xfffffc00,	"movfr2gr.d",	"r0:5,f5:5",			0,			0,	0,	0 },
+@@ -1424,6 +1428,10 @@ static struct loongarch_opcode loongarch_lsx_opcodes[] =
+   { 0x729cf800, 0xfffffc00, "vfrecip.d",	"v0:5,v5:5",		0, 0, 0, 0},
+   { 0x729d0400, 0xfffffc00, "vfrsqrt.s",	"v0:5,v5:5",		0, 0, 0, 0},
+   { 0x729d0800, 0xfffffc00, "vfrsqrt.d",	"v0:5,v5:5",		0, 0, 0, 0},
++  { 0x729d1400, 0xfffffc00, "vfrecipe.s",	"v0:5,v5:5",		0, 0, 0, 0},
++  { 0x729d1800, 0xfffffc00, "vfrecipe.d",	"v0:5,v5:5",		0, 0, 0, 0},
++  { 0x729d2400, 0xfffffc00, "vfrsqrte.s",	"v0:5,v5:5",		0, 0, 0, 0},
++  { 0x729d2800, 0xfffffc00, "vfrsqrte.d",	"v0:5,v5:5",		0, 0, 0, 0},
+   { 0x729d3400, 0xfffffc00, "vfrint.s",		"v0:5,v5:5",		0, 0, 0, 0},
+   { 0x729d3800, 0xfffffc00, "vfrint.d",		"v0:5,v5:5",		0, 0, 0, 0},
+   { 0x729d4400, 0xfffffc00, "vfrintrm.s",	"v0:5,v5:5",		0, 0, 0, 0},
+@@ -2169,6 +2177,10 @@ static struct loongarch_opcode loongarch_lasx_opcodes[] =
+   { 0x769cf800, 0xfffffc00, "xvfrecip.d",	"x0:5,x5:5",		0, 0, 0, 0},
+   { 0x769d0400, 0xfffffc00, "xvfrsqrt.s",	"x0:5,x5:5",		0, 0, 0, 0},
+   { 0x769d0800, 0xfffffc00, "xvfrsqrt.d",	"x0:5,x5:5",		0, 0, 0, 0},
++  { 0x769d1400, 0xfffffc00, "xvfrecipe.s",	"x0:5,x5:5",		0, 0, 0, 0},
++  { 0x769d1800, 0xfffffc00, "xvfrecipe.d",	"x0:5,x5:5",		0, 0, 0, 0},
++  { 0x769d2400, 0xfffffc00, "xvfrsqrte.s",	"x0:5,x5:5",		0, 0, 0, 0},
++  { 0x769d2800, 0xfffffc00, "xvfrsqrte.d",	"x0:5,x5:5",		0, 0, 0, 0},
+   { 0x769d3400, 0xfffffc00, "xvfrint.s",	"x0:5,x5:5",		0, 0, 0, 0},
+   { 0x769d3800, 0xfffffc00, "xvfrint.d",	"x0:5,x5:5",		0, 0, 0, 0},
+   { 0x769d4400, 0xfffffc00, "xvfrintrm.s",	"x0:5,x5:5",		0, 0, 0, 0},
+-- 
+2.43.4
+

--- a/debian/patches/0010-LoongArch-Modify-inconsistent-behavior-of-ld-with-un.patch
+++ b/debian/patches/0010-LoongArch-Modify-inconsistent-behavior-of-ld-with-un.patch
@@ -1,0 +1,60 @@
+From 577d54414be9f1b13536b398a0b0ef16a9629d48 Mon Sep 17 00:00:00 2001
+From: ticat_fp <fanpeng@loongson.cn>
+Date: Mon, 26 Feb 2024 11:11:35 +0800
+Subject: [PATCH 10/12] LoongArch: Modify inconsistent behavior of ld with
+ --unresolved-symbols=ignore-all
+
+Remove duplicated check when producing executable files that reference external symbols
+defined in other files. RELOC_FOR_GLOBAL_SYMBOL will check it.
+
+Testcase is:
+resolv.c:
+int main(int argc, char *argv[]) {
+    return argc;
+}
+
+t.c:
+
+extern const struct my_struct ms1;
+static const struct my_struct *ms = &ms1;
+
+t.h:
+typedef struct my_struct {
+    char *str;
+    int i;
+} my_struct;
+
+Compiling and linking command with:
+gcc t.c -c ; gcc resolv.c -c
+gcc resolv.o t.o -o resolv -Wl,--unresolved-symbols=ignore-all
+
+Got error as:
+~/install/usr/bin/ld: t.o:(.data.rel+0x0): undefined reference to `ms1'
+collect2: error: ld returned 1 exit status
+---
+ bfd/elfnn-loongarch.c | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index db9f106a8b0..f7dc7279480 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -2575,14 +2575,7 @@ loongarch_elf_relocate_section (bfd *output_bfd, struct bfd_link_info *info,
+ 	      else if (resolved_dynly)
+ 		{
+ 		  if (h->dynindx == -1)
+-		    {
+-		      if (h->root.type == bfd_link_hash_undefined)
+-			(*info->callbacks->undefined_symbol)
+-			  (info, name, input_bfd, input_section,
+-			   rel->r_offset, true);
+-
+-		      outrel.r_info = ELFNN_R_INFO (0, r_type);
+-		    }
++		    outrel.r_info = ELFNN_R_INFO (0, r_type);
+ 		  else
+ 		    outrel.r_info = ELFNN_R_INFO (h->dynindx, r_type);
+ 
+-- 
+2.43.4
+

--- a/debian/patches/0011-as-add-option-for-generate-R_LARCH_32-64_PCREL.patch
+++ b/debian/patches/0011-as-add-option-for-generate-R_LARCH_32-64_PCREL.patch
@@ -1,0 +1,124 @@
+From 074f76fa023a18df9424ebb0a678bb7ea0d82e18 Mon Sep 17 00:00:00 2001
+From: cailulu <cailulu@loongson.cn>
+Date: Thu, 28 Sep 2023 16:01:52 +0800
+Subject: [PATCH 11/12] as: add option for generate R_LARCH_32/64_PCREL.
+
+Some older kernels cannot handle the newly generated R_LARCH_32/64_PCREL,
+so the assembler generates R_LARCH_ADD32/64+R_LARCH_SUB32/64 by default,
+and use the assembler option mthin-add-sub to generate R_LARCH_32/64_PCREL
+as much as possible.
+
+The Option of mthin-add-sub does not affect the generation of R_LARCH_32_PCREL
+relocation in .eh_frame.
+---
+ gas/config/tc-loongarch.c  | 28 ++++++++++++++++++++++++++++
+ gas/config/tc-loongarch.h  | 13 +++++++++++--
+ include/opcode/loongarch.h |  1 +
+ 3 files changed, 40 insertions(+), 2 deletions(-)
+
+diff --git a/gas/config/tc-loongarch.c b/gas/config/tc-loongarch.c
+index 29a14e7402e..00bda0eafc1 100644
+--- a/gas/config/tc-loongarch.c
++++ b/gas/config/tc-loongarch.c
+@@ -120,6 +120,7 @@ enum options
+   OPTION_LA_GLOBAL_WITH_ABS,
+   OPTION_RELAX,
+   OPTION_NO_RELAX,
++  OPTION_THIN_ADD_SUB,
+ 
+   OPTION_END_OF_ENUM,
+ };
+@@ -136,6 +137,7 @@ struct option md_longopts[] =
+ 
+   { "mrelax", no_argument, NULL, OPTION_RELAX },
+   { "mno-relax", no_argument, NULL, OPTION_NO_RELAX },
++  { "mthin-add-sub", no_argument, NULL, OPTION_THIN_ADD_SUB},
+ 
+   { NULL, no_argument, NULL, 0 }
+ };
+@@ -214,6 +216,10 @@ md_parse_option (int c, const char *arg)
+       LARCH_opts.relax = 0;
+       break;
+ 
++    case OPTION_THIN_ADD_SUB:
++      LARCH_opts.thin_add_sub = 1;
++      break;
++
+     case OPTION_IGNORE:
+       break;
+ 
+@@ -1287,6 +1293,23 @@ md_apply_fix (fixS *fixP, valueT *valP, segT seg ATTRIBUTE_UNUSED)
+ 	  break;
+ 	}
+ 
++      /* If symbol in .eh_frame the address may be adjusted, and contents of
++	 .eh_frame will be adjusted, so use pc-relative relocation for FDE
++	 initial location.
++	 The Option of mthin-add-sub does not affect the generation of
++	 R_LARCH_32_PCREL relocation in .eh_frame.  */
++      if (fixP->fx_r_type == BFD_RELOC_32
++	  && fixP->fx_addsy && fixP->fx_subsy
++	  && (sub_segment = S_GET_SEGMENT (fixP->fx_subsy))
++	  && strcmp (sub_segment->name, ".eh_frame") == 0
++	  && S_GET_VALUE (fixP->fx_subsy)
++	  == fixP->fx_frag->fr_address + fixP->fx_where)
++	{
++	  fixP->fx_r_type = BFD_RELOC_LARCH_32_PCREL;
++	  fixP->fx_subsy = NULL;
++	  break;
++	}
++
+       if (fixP->fx_addsy && fixP->fx_subsy)
+ 	{
+ 	  fixP->fx_next = xmemdup (fixP, sizeof (*fixP), sizeof (*fixP));
+@@ -1589,6 +1612,11 @@ md_show_usage (FILE *stream)
+ {
+   fprintf (stream, _("LARCH options:\n"));
+   /* FIXME */
++  fprintf (stream, _("\
++  -mthin-add-sub	  Convert a pair of R_LARCH_ADD32/64 and R_LARCH_SUB32/64 to\n\
++			  R_LARCH_32/64_PCREL as much as possible\n\
++			  The option does not affect the generation of R_LARCH_32_PCREL\n\
++			  relocations in .eh_frame\n"));
+ }
+ 
+ static void
+diff --git a/gas/config/tc-loongarch.h b/gas/config/tc-loongarch.h
+index a9f2a0a17cc..e700cbb4a7f 100644
+--- a/gas/config/tc-loongarch.h
++++ b/gas/config/tc-loongarch.h
+@@ -71,8 +71,17 @@ extern bool loongarch_frag_align_code (int);
+    relaxation, so do not resolve such expressions in the assembler.  */
+ #define md_allow_local_subtract(l,r,s) 0
+ 
+-/* Values passed to md_apply_fix don't include symbol values.  */
+-#define TC_FORCE_RELOCATION_SUB_LOCAL(FIX, SEG) 1
++/* If subsy of BFD_RELOC32/64 and PC in same segment, and without relax
++   or PC at start of subsy or with relax but sub_symbol_segment not in
++   SEC_CODE, we generate 32/64_PCREL.  */
++#define TC_FORCE_RELOCATION_SUB_LOCAL(FIX, SEG) \
++  (!(LARCH_opts.thin_add_sub \
++     && (BFD_RELOC_32 || BFD_RELOC_64) \
++     && (!LARCH_opts.relax \
++	|| S_GET_VALUE (FIX->fx_subsy) \
++	   == FIX->fx_frag->fr_address + FIX->fx_where \
++	|| (LARCH_opts.relax \
++	   && ((S_GET_SEGMENT (FIX->fx_subsy)->flags & SEC_CODE) == 0)))))
+ 
+ #define TC_VALIDATE_FIX_SUB(FIX, SEG) 1
+ #define DIFF_EXPR_OK 1
+diff --git a/include/opcode/loongarch.h b/include/opcode/loongarch.h
+index e145db5e8a6..2ed4082cf43 100644
+--- a/include/opcode/loongarch.h
++++ b/include/opcode/loongarch.h
+@@ -236,6 +236,7 @@ dec2 : [1-9][0-9]?
+ #define ase_gabs	isa.use_la_global_with_abs
+ 
+     int relax;
++    int thin_add_sub;
+   } LARCH_opts;
+ 
+   extern size_t loongarch_insn_length (insn_t insn);
+-- 
+2.43.4
+

--- a/debian/patches/0012-Add-testsuits-for-new-assembler-option-of-mthin-add-.patch
+++ b/debian/patches/0012-Add-testsuits-for-new-assembler-option-of-mthin-add-.patch
@@ -1,0 +1,371 @@
+From 6ef4d02ca5f82e063363857669ca771d57c5d7e7 Mon Sep 17 00:00:00 2001
+From: cailulu <cailulu@loongson.cn>
+Date: Thu, 28 Sep 2023 16:01:53 +0800
+Subject: [PATCH 12/12] Add testsuits for new assembler option of
+ mthin-add-sub.
+
+---
+ gas/testsuite/gas/loongarch/no_thin_add_sub.d | 66 +++++++++++++++++++
+ gas/testsuite/gas/loongarch/no_thin_add_sub.s | 44 +++++++++++++
+ .../gas/loongarch/thin_add_sub_norelax.d      | 53 +++++++++++++++
+ .../gas/loongarch/thin_add_sub_norelax.s      | 42 ++++++++++++
+ .../gas/loongarch/thin_add_sub_relax.d        | 60 +++++++++++++++++
+ .../gas/loongarch/thin_add_sub_relax.s        | 46 +++++++++++++
+ 6 files changed, 311 insertions(+)
+ create mode 100644 gas/testsuite/gas/loongarch/no_thin_add_sub.d
+ create mode 100644 gas/testsuite/gas/loongarch/no_thin_add_sub.s
+ create mode 100644 gas/testsuite/gas/loongarch/thin_add_sub_norelax.d
+ create mode 100644 gas/testsuite/gas/loongarch/thin_add_sub_norelax.s
+ create mode 100644 gas/testsuite/gas/loongarch/thin_add_sub_relax.d
+ create mode 100644 gas/testsuite/gas/loongarch/thin_add_sub_relax.s
+
+diff --git a/gas/testsuite/gas/loongarch/no_thin_add_sub.d b/gas/testsuite/gas/loongarch/no_thin_add_sub.d
+new file mode 100644
+index 00000000000..614aca71d66
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/no_thin_add_sub.d
+@@ -0,0 +1,66 @@
++#as:
++#objdump: -Dr
++
++.*:[    ]+file format .*
++
++
++Disassembly of section .text:
++
++00000000.* <.L1>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+0:[ 	]+R_LARCH_SUB32[ 	]+.L1
++[ 	]+4:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+4:[ 	]+R_LARCH_SUB32[ 	]+.L1
++
++0*00000008[ 	]+<.L2>:
++[ 	]+...
++[ 	]+8:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+8:[ 	]+R_LARCH_SUB64[ 	]+.L2
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L2
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sx:
++
++0*00000000[ 	]+<.L3>:
++[ 	]+0:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+8:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++
++0*0000000c[ 	]+<.L4>:
++[ 	]+...
++[ 	]+c:[ 	]+R_LARCH_ADD32[ 	]+.L4
++[ 	]+c:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L4
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L5
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sy:
++
++0*00000000[ 	]+<.L5>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_ADD32[ 	]+.L1
++[ 	]+0:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+4:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+4:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+8:[ 	]+R_LARCH_ADD64[ 	]+.L1
++[ 	]+8:[ 	]+R_LARCH_SUB64[ 	]+.L5
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L5
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sz:
++
++0*00000000[ 	]+<sz>:
++[ 	]+0:[ 	]+00000000[ 	]+.word[ 	]+0x00000000
++[ 	]+0:[ 	]+R_LARCH_ADD32[ 	]+.L1
++[ 	]+0:[ 	]+R_LARCH_SUB32[ 	]+.L2
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+...
++[ 	]+8:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+8:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+c:[ 	]+R_LARCH_ADD64[ 	]+.L1
++[ 	]+c:[ 	]+R_LARCH_SUB64[ 	]+.L2
++[ 	]+14:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+18:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++[ 	]+...
++[ 	]+1c:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+1c:[ 	]+R_LARCH_SUB64[ 	]+.L5
+diff --git a/gas/testsuite/gas/loongarch/no_thin_add_sub.s b/gas/testsuite/gas/loongarch/no_thin_add_sub.s
+new file mode 100644
+index 00000000000..c680168956f
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/no_thin_add_sub.s
+@@ -0,0 +1,44 @@
++  .section .text
++.L1:
++  # add32+sub32
++  .4byte .L3-.L1
++  .4byte .L3-.L1
++.L2:
++  # add64+sub64
++  .8byte .L3-.L2
++  .8byte .L3-.L2
++
++  .section sx
++.L3:
++  # no relocation
++  .4byte .L3-.L4
++  .8byte .L3-.L4
++.L4:
++  # add32+sub32
++  .4byte .L4-.L5
++  # add64+sub64
++  .8byte .L4-.L5
++
++  .section sy
++.L5:
++  # add32+sub32
++  .4byte .L1-.L5
++  .4byte .L3-.L5
++  # add64+sub64
++  .8byte .L1-.L5
++  .8byte .L3-.L5
++
++  .section sz
++  # add32+sub32
++  .4byte .L1-.L2
++  # no relocation
++  .4byte .L3-.L4
++  # add32+sub32
++  .4byte .L3-.L5
++
++  # add64+sub64
++  .8byte .L1-.L2
++  # no relocation
++  .8byte .L3-.L4
++  # add64+sub64
++  .8byte .L3-.L5
+diff --git a/gas/testsuite/gas/loongarch/thin_add_sub_norelax.d b/gas/testsuite/gas/loongarch/thin_add_sub_norelax.d
+new file mode 100644
+index 00000000000..702093b6997
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/thin_add_sub_norelax.d
+@@ -0,0 +1,53 @@
++#as: -mthin-add-sub -mno-relax
++#objdump: -Dr
++
++.*:[    ]+file format .*
++
++
++Disassembly of section .text:
++
++00000000.* <.L1>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_32_PCREL[ 	]+.L3
++[ 	]+4:[ 	]+R_LARCH_32_PCREL[ 	]+.L3\+0x4
++[ 	]+8:[ 	]+R_LARCH_64_PCREL[ 	]+.L3
++[ 	]+10:[ 	]+R_LARCH_64_PCREL[ 	]+.L3\+0x8
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sx:
++
++0*00000000[ 	]+<.L3>:
++[ 	]+0:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+8:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++
++0*0000000c[ 	]+<.L4>:
++[ 	]+...
++[ 	]+c:[ 	]+R_LARCH_ADD32[ 	]+.L4
++[ 	]+c:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L4
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L5
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sy:
++
++0*00000000[ 	]+<.L5>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_32_PCREL[ 	]+.L1
++[ 	]+4:[ 	]+R_LARCH_32_PCREL[ 	]+.L3\+0x4
++[ 	]+8:[ 	]+R_LARCH_64_PCREL[ 	]+.L1\+0x8
++[ 	]+10:[ 	]+R_LARCH_64_PCREL[ 	]+.L3\+0x10
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sz:
++
++0*00000000[ 	]+<sz>:
++[ 	]+0:[ 	]+fffffff8[ 	]+.word[ 	]+0xfffffff8
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+8:[ 	]+00000000[ 	]+.word[ 	]+0x00000000
++[ 	]+8:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+8:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+c:[ 	]+fffffff8[ 	]+.word[ 	]+0xfffffff8
++[ 	]+10:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++[ 	]+14:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+18:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++[ 	]+...
++[ 	]+1c:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+1c:[ 	]+R_LARCH_SUB64[ 	]+.L5
+diff --git a/gas/testsuite/gas/loongarch/thin_add_sub_norelax.s b/gas/testsuite/gas/loongarch/thin_add_sub_norelax.s
+new file mode 100644
+index 00000000000..94cfd90870c
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/thin_add_sub_norelax.s
+@@ -0,0 +1,42 @@
++  .section .text
++.L1:
++  # 32_pcrel
++  .4byte .L3-.L1
++  .4byte .L3-.L1
++.L2:
++  # 64_pcrel
++  .8byte .L3-.L2
++  .8byte .L3-.L2
++
++  .section sx
++.L3:
++  # no relocation
++  .4byte .L3-.L4
++  .8byte .L3-.L4
++.L4:
++  # add32+sub32
++  .4byte .L4-.L5
++  # add64+sub64
++  .8byte .L4-.L5
++
++  .section sy
++.L5:
++  # 32_pcrel
++  .4byte .L1-.L5
++  .4byte .L3-.L5
++  # 64_pcrel
++  .8byte .L1-.L5
++  .8byte .L3-.L5
++
++  .section sz
++  # no relocation
++  .4byte .L1-.L2
++  .4byte .L3-.L4
++  # add32+sub32
++  .4byte .L3-.L5
++
++  # no relocation
++  .8byte .L1-.L2
++  .8byte .L3-.L4
++  # add64+sub64
++  .8byte .L3-.L5
+diff --git a/gas/testsuite/gas/loongarch/thin_add_sub_relax.d b/gas/testsuite/gas/loongarch/thin_add_sub_relax.d
+new file mode 100644
+index 00000000000..9455c3e66bf
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/thin_add_sub_relax.d
+@@ -0,0 +1,60 @@
++#as: -mthin-add-sub
++#objdump: -Dr
++
++.*:[    ]+file format .*
++
++
++Disassembly of section .text:
++
++00000000.* <.L1>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_32_PCREL[ 	]+.L3
++[ 	]+4:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+4:[ 	]+R_LARCH_SUB32[ 	]+.L1
++
++0*00000008[ 	]+<.L2>:
++[ 	]+...
++[ 	]+8:[ 	]+R_LARCH_64_PCREL[ 	]+.L3
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L2
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sx:
++
++0*00000000[ 	]+<.L3>:
++[ 	]+0:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+8:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++
++0*0000000c[ 	]+<.L4>:
++[ 	]+...
++[ 	]+c:[ 	]+R_LARCH_ADD32[ 	]+.L4
++[ 	]+c:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+10:[ 	]+R_LARCH_ADD64[ 	]+.L4
++[ 	]+10:[ 	]+R_LARCH_SUB64[ 	]+.L5
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sy:
++
++0*00000000[ 	]+<.L5>:
++[ 	]+...
++[ 	]+0:[ 	]+R_LARCH_32_PCREL[ 	]+.L1
++[ 	]+4:[ 	]+R_LARCH_32_PCREL[ 	]+.L3\+0x4
++[ 	]+8:[ 	]+R_LARCH_64_PCREL[ 	]+.L1\+0x8
++[ 	]+10:[ 	]+R_LARCH_64_PCREL[ 	]+.L3\+0x10
++
++Disassembly[ 	]+of[ 	]+section[ 	]+sz:
++
++0*00000000[ 	]+<sz>:
++[ 	]+0:[ 	]+00000000[ 	]+.word[ 	]+0x00000000
++[ 	]+0:[ 	]+R_LARCH_ADD32[ 	]+.L1
++[ 	]+0:[ 	]+R_LARCH_SUB32[ 	]+.L2
++[ 	]+4:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+...
++[ 	]+8:[ 	]+R_LARCH_ADD32[ 	]+.L3
++[ 	]+8:[ 	]+R_LARCH_SUB32[ 	]+.L5
++[ 	]+c:[ 	]+R_LARCH_ADD64[ 	]+.L1
++[ 	]+c:[ 	]+R_LARCH_SUB64[ 	]+.L2
++[ 	]+14:[ 	]+fffffff4[ 	]+.word[ 	]+0xfffffff4
++[ 	]+18:[ 	]+ffffffff[ 	]+.word[ 	]+0xffffffff
++[ 	]+...
++[ 	]+1c:[ 	]+R_LARCH_ADD64[ 	]+.L3
++[ 	]+1c:[ 	]+R_LARCH_SUB64[ 	]+.L5
+diff --git a/gas/testsuite/gas/loongarch/thin_add_sub_relax.s b/gas/testsuite/gas/loongarch/thin_add_sub_relax.s
+new file mode 100644
+index 00000000000..ded275fa72c
+--- /dev/null
++++ b/gas/testsuite/gas/loongarch/thin_add_sub_relax.s
+@@ -0,0 +1,46 @@
++  .section .text
++.L1:
++  # 32_pcrel
++  .4byte .L3-.L1
++  # add32+sub32
++  .4byte .L3-.L1
++.L2:
++  # 64_pcrel
++  .8byte .L3-.L2
++  # add64+sub64
++  .8byte .L3-.L2
++
++  .section sx
++.L3:
++  # no relocation
++  .4byte .L3-.L4
++  .8byte .L3-.L4
++.L4:
++  # add32+sub32
++  .4byte .L4-.L5
++  # add64+sub64
++  .8byte .L4-.L5
++
++  .section sy
++.L5:
++  # 32_pcrel
++  .4byte .L1-.L5
++  .4byte .L3-.L5
++  # 64_pcrel
++  .8byte .L1-.L5
++  .8byte .L3-.L5
++
++  .section sz
++  # add32+sub32
++  .4byte .L1-.L2
++  # no relocation
++  .4byte .L3-.L4
++  # add32+sub32
++  .4byte .L3-.L5
++
++  #add64+sub64
++  .8byte .L1-.L2
++  # no relocation
++  .8byte .L3-.L4
++  #add64+sub64
++  .8byte .L3-.L5
+-- 
+2.43.4
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -39,3 +39,17 @@ perl-shebang.diff
 
 link-jansson.diff
 pr30700.diff
+
+# LoongArch backports.
+0001-LoongArch-Fix-ld-no-relax-bug.patch
+0002-LoongArch-Directly-delete-relaxed-instuctions-in-fir.patch
+0003-LoongArch-Multiple-relax_trip-in-one-relax_pass.patch
+0004-LoongArch-Remove-elf_seg_map-info-output_bfd-NULL-re.patch
+0005-LoongArch-Modify-link_info.relax_pass-from-3-to-2.patch
+0006-LoongArch-Add-more-relaxation-testcases.patch
+0007-LoongArch-fix-internal-error-when-as-handling-unsupp.patch
+0008-as-Add-new-atomic-instructions-in-LoongArch-v1.1.patch
+0009-as-Add-new-estimated-reciprocal-instructions-in-Loon.patch
+0010-LoongArch-Modify-inconsistent-behavior-of-ld-with-un.patch
+0011-as-add-option-for-generate-R_LARCH_32-64_PCREL.patch
+0012-Add-testsuits-for-new-assembler-option-of-mthin-add-.patch

--- a/debian/rules
+++ b/debian/rules
@@ -120,9 +120,8 @@ install_script = install -m 755
 install_binary = install -m 755 -s --strip-program="$(STRIP)"
 
 NATIVE_ARCHS ?= amd64 i386 arm64 armhf armel ppc64el s390x
-NATIVE_ARCHS += arc hppa ia64 loong64 m68k powerpc ppc64 \
+NATIVE_ARCHS += arc hppa loong64 m68k powerpc \
 	riscv64 sh4 sparc64 x32
-NATIVE_ARCHS += hurd-amd64 hurd-i386 kfreebsd-amd64 kfreebsd-i386
 #NATIVE_ARCHS += nios2 or1k s390 sparc
 
 # don't generate the control file entries for native packages which are never
@@ -142,16 +141,19 @@ ifeq ($(DEB_SOURCE),binutils)
     CROSS_ARCHS ?= amd64 i386 x32 \
                    s390x ppc64el arm64 armhf armel \
                    arc hppa loong64 m68k \
-                   powerpc ppc64 sh4 sparc64 \
-                   ia64 riscv64 \
-                   kfreebsd-amd64 kfreebsd-i386 hurd-amd64 hurd-i386
+                   powerpc sh4 sparc64 \
+                   riscv64
   else ifeq ($(DEB_HOST_ARCH),arm64)
     CROSS_ARCHS ?= amd64 armel armhf i386 powerpc ppc64el riscv64 s390x \
 		   arc hppa m68k sh4 sparc64 x32
-  else ifeq ($(DEB_HOST_ARCH),ppc64)
-    CROSS_ARCHS ?= ppc64el
+  else ifeq ($(DEB_HOST_ARCH),loong64)
+    CROSS_ARCHS ?= amd64 arm64 armel armhf i386 powerpc ppc64el riscv64 s390x \
+		   arc hppa m68k sh4 sparc64 x32
   else ifeq ($(DEB_HOST_ARCH),ppc64el)
-    CROSS_ARCHS ?= powerpc ppc64 amd64 armel armhf arm64 i386 riscv64 s390x \
+    CROSS_ARCHS ?= powerpc amd64 armel armhf arm64 i386 riscv64 s390x \
+		   arc hppa m68k sh4 sparc64 x32
+  else ifeq ($(DEB_HOST_ARCH),riscv64)
+    CROSS_ARCHS ?= amd64 arm64 armel armhf i386 loong64 powerpc ppc64el s390x \
 		   arc hppa m68k sh4 sparc64 x32
   endif
 else ifeq ($(DEB_SOURCE),binutils-ports)
@@ -193,45 +195,38 @@ ifneq (,$(filter $(DEB_HOST_ARCH),amd64 i386 arm64 x32))
   CONF_GPROFNG = --enable-gprofng
 endif
 
-HOST_ARCHS_armhf = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_armel = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_arm64 = amd64 i386 x32 ppc64el
-HOST_ARCHS_powerpc = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_ppc64el = amd64 i386 x32 ppc64 arm64
-HOST_ARCHS_s390x = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_amd64 = arm64 i386 ppc64el x32
-HOST_ARCHS_i386 = amd64 arm64 ppc64el x32
-HOST_ARCHS_ia64 = amd64 i386 x32
-HOST_ARCHS_riscv64 = amd64 i386 x32 arm64 ppc64el
+HOST_ARCHS_armhf = amd64 i386 x32 arm64 ppc64el loong64 riscv64
+HOST_ARCHS_armel = amd64 i386 x32 arm64 ppc64el loong64 riscv64
+HOST_ARCHS_arm64 = amd64 i386 x32 ppc64el loong64 riscv64
+HOST_ARCHS_powerpc = amd64 i386 x32 arm64 ppc64el loong64 riscv64
+HOST_ARCHS_ppc64el = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_s390x = amd64 i386 x32 arm64 ppc64el loong64 riscv64
+HOST_ARCHS_amd64 = arm64 i386 ppc64el x32 arm64 loong64 riscv64
+HOST_ARCHS_i386 = amd64 arm64 ppc64el x32 arm64 loong64 riscv64
+HOST_ARCHS_riscv64 = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_loong64 = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 
-# HOST_ARCHS_alpha = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_arc = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_hppa = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_loong64 = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_m68k = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_ppc64 = amd64 i386 x32 ppc64el
-HOST_ARCHS_sh4 = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_sparc64 = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_x32 = amd64 arm64 i386 ppc64el
+HOST_ARCHS_arc = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_hppa = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_loong64 = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_m68k = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_sh4 = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_sparc64 = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
+HOST_ARCHS_x32 = amd64 arm64 i386 ppc64el arm64 loong64 riscv64
 
-HOST_ARCHS_mips = amd64 i386 x32
-HOST_ARCHS_mipsel = amd64 i386 x32 arm64 ppc64el
-HOST_ARCHS_mipsn32 = amd64 i386 x32
-HOST_ARCHS_mipsn32el = amd64 i386 x32
-HOST_ARCHS_mips64 = amd64 i386 x32
-HOST_ARCHS_mips64el = amd64 i386 x32 arm64 ppc64el
+HOST_ARCHS_mips = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mipsel = amd64 i386 x32 arm64 ppc64el loong64 riscv64
+HOST_ARCHS_mipsn32 = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mipsn32el = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mips64 = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mips64el = amd64 i386 x32 arm64 ppc64el arm64 loong64 riscv64
 
-HOST_ARCHS_mipsr6 = amd64 i386 x32
-HOST_ARCHS_mipsr6el = amd64 i386 x32
-HOST_ARCHS_mipsn32r6 = amd64 i386 x32
-HOST_ARCHS_mipsn32r6el = amd64 i386 x32
-HOST_ARCHS_mips64r6 = amd64 i386 x32
-HOST_ARCHS_mips64r6el = amd64 i386 x32
-
-HOST_ARCHS_kfreebsd-amd64 = amd64 i386 x32
-HOST_ARCHS_kfreebsd-i386 = amd64 i386 x32
-HOST_ARCHS_hurd-amd64 = amd64 i386 x32
-HOST_ARCHS_hurd-i386 = amd64 i386 x32
+HOST_ARCHS_mipsr6 = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mipsr6el = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mipsn32r6 = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mipsn32r6el = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mips64r6 = amd64 i386 x32 arm64 loong64 riscv64
+HOST_ARCHS_mips64r6el = amd64 i386 x32 arm64 loong64 riscv64
 
 # Map a Debian architecture alias to a GNU type or a multiarch path component.
 run_dpkg_arch = $(or $(dpkg_arch_$1),$(eval \
@@ -286,7 +281,7 @@ gold_targets = \
 	amd64 arm64 armel armhf i386 \
 	mips mipsel mipsn32 mipsn32el mips64 mips64el \
 	mipsr6 mipsr6el mipsn32r6 mipsn32r6el mips64r6 mips64r6el \
-	powerpc ppc64 ppc64el sparc sparc64 s390x \
+	powerpc ppc64el sparc sparc64 s390x \
 	x32 kfreebsd-amd64 kfreebsd-i386 hurd-i386
 
 ifneq (,$(filter $(DEB_HOST_ARCH), $(gold_targets)))
@@ -756,7 +751,6 @@ multiarch_targets = \
 	arm-linux-gnueabi \
 	hppa-linux-gnu \
 	i686-linux-gnu \
-	ia64-linux-gnu \
 	loongarch64-linux-gnu \
 	m32r-linux-gnu \
 	m68k-linux-gnu \
@@ -1178,7 +1172,7 @@ endif
 	rm -rf $(d_bin)/$(PF)/include/obstack.h
 	rm -f $(d_doc)/$(PF)/share/info/configure.* $(d_doc)/$(PF)/share/info/standards.*
 
-ifneq (,$(filter $(DEB_HOST_ARCH),powerpc ppc64 ppc64el))
+ifneq (,$(filter $(DEB_HOST_ARCH),powerpc ppc64el))
 	rm -f $(d_bin)/$(PF)/bin/embedspu
 endif
 
@@ -1208,7 +1202,7 @@ ifeq ($(with_multiarch),yes)
 	rm -f $(d_mul)/$(PF)/bin/gp-*
 	rm -rf $(d_mul)/$(PF)/lib/*/gprofng
 
-  ifneq (,$(filter $(DEB_HOST_ARCH),powerpc ppc64 ppc64el))
+  ifneq (,$(filter $(DEB_HOST_ARCH),powerpc ppc64el))
 	rm -f $(d_mul)/$(PF)/bin/embedspu
   endif
 	rm -rf $(d_mul)/$(PF)/lib/$(DEB_HOST_MULTIARCH)/ldscripts


### PR DESCRIPTION
- Enable  full cross compilation set for amd64, arm64, loong64, and riscv64.
- Backport fixes for LoongArch from upstream (binutils-2_41-branch, master).
- Drop ia64, ppc64, kfreebsd, hurd targets.