### PR TITLE
fix: fix multiple CVEs for binutils

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+binutils (2.41-6deepin12) unstable; urgency=medium
+
+  * Fix multiple CVEs
+    - CVE-2025-11082: elf: Don't read beyond .eh_frame section size
+    - CVE-2025-11412: PR 33452 SEGV in bfd_elf_gc_record_vtentry
+    - CVE-2025-11494: x86: Keep _GLOBAL_OFFSET_TABLE_ for .eh_frame
+    - CVE-2025-11495: x86: Disallow TLS relocation in non executable section
+    - CVE-2025-11839: Remove call to abort in DGB debug format printing
+    - CVE-2025-11840: PR 33455 SEGV in vfinfo at ldmisc.c
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 22 Apr 2026 18:05:10 +0800
+
 binutils (2.41-6deepin11) unstable; urgency=medium
 
   * LoongArch: common sync from upstream

--- a/debian/patches/CVE-2025-11082.patch
+++ b/debian/patches/CVE-2025-11082.patch
@@ -1,0 +1,45 @@
+From ea1a0737c7692737a644af0486b71e4a392cbca8 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 22 Sep 2025 15:20:34 +0800
+Subject: [PATCH] elf: Don't read beyond .eh_frame section size
+
+	PR ld/33464
+	* elf-eh-frame.c (_bfd_elf_parse_eh_frame): Don't read beyond
+	.eh_frame section size.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elf-eh-frame.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/bfd/elf-eh-frame.c b/bfd/elf-eh-frame.c
+index dc0d2e097f5..30bb313489c 100644
+--- a/bfd/elf-eh-frame.c
++++ b/bfd/elf-eh-frame.c
+@@ -737,6 +737,7 @@ _bfd_elf_parse_eh_frame (bfd *abfd, struct bfd_link_info *info,
+       if (hdr_id == 0)
+ 	{
+ 	  unsigned int initial_insn_length;
++	  char *null_byte;
+ 
+ 	  /* CIE  */
+ 	  this_inf->cie = 1;
+@@ -753,10 +754,13 @@ _bfd_elf_parse_eh_frame (bfd *abfd, struct bfd_link_info *info,
+ 	  REQUIRE (cie->version == 1
+ 		   || cie->version == 3
+ 		   || cie->version == 4);
+-	  REQUIRE (strlen ((char *) buf) < sizeof (cie->augmentation));
++	  null_byte = memchr ((char *) buf, 0, end - buf);
++	  REQUIRE (null_byte != NULL);
++	  REQUIRE ((size_t) (null_byte - (char *) buf)
++		   < sizeof (cie->augmentation));
+ 
+ 	  strcpy (cie->augmentation, (char *) buf);
+-	  buf = (bfd_byte *) strchr ((char *) buf, '\0') + 1;
++	  buf = (bfd_byte *) null_byte + 1;
+ 	  this_inf->u.cie.aug_str_len = buf - start - 1;
+ 	  ENSURE_NO_RELOCS (buf);
+ 	  if (buf[0] == 'e' && buf[1] == 'h')
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11412.patch
+++ b/debian/patches/CVE-2025-11412.patch
@@ -1,0 +1,34 @@
+From 047435dd988a3975d40c6626a8f739a0b2e154bc Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Thu, 25 Sep 2025 08:22:24 +0930
+Subject: [PATCH] PR 33452 SEGV in bfd_elf_gc_record_vtentry
+
+Limit addends on vtentry relocs, otherwise ld might attempt to
+allocate a stupidly large array.  This also fixes the expression
+overflow leading to pr33452.  A vtable of 33M entries on a 64-bit
+host is surely large enough, especially considering that VTINHERIT
+and VTENTRY relocations are to support -fvtable-gc that disappeared
+from gcc over 20 years ago.
+
+	PR ld/33452
+	* elflink.c (bfd_elf_gc_record_vtentry): Sanity check addend.
+---
+ bfd/elflink.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 54f0d6e957e..0a0456177c2 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -14865,7 +14865,7 @@ bfd_elf_gc_record_vtentry (bfd *abfd, asection *sec,
+   const struct elf_backend_data *bed = get_elf_backend_data (abfd);
+   unsigned int log_file_align = bed->s->log_file_align;
+ 
+-  if (!h)
++  if (!h || addend > 1u << 28)
+     {
+       /* xgettext:c-format */
+       _bfd_error_handler (_("%pB: section '%pA': corrupt VTENTRY entry"),
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11494.patch
+++ b/debian/patches/CVE-2025-11494.patch
@@ -1,0 +1,48 @@
+From b6ac5a8a5b82f0ae6a4642c8d7149b325f4cc60a Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 30 Sep 2025 08:13:56 +0800
+Subject: [PATCH] x86: Keep _GLOBAL_OFFSET_TABLE_ for .eh_frame
+
+Since x86 .eh_frame section may reference _GLOBAL_OFFSET_TABLE_, keep
+_GLOBAL_OFFSET_TABLE_ if there is dynamic section and the output
+.eh_frame section is non-empty.
+
+	PR ld/33499
+	* elfxx-x86.c (_bfd_x86_elf_late_size_sections): Keep
+	_GLOBAL_OFFSET_TABLE_ if there is dynamic section and the
+	output .eh_frame section is non-empty.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elfxx-x86.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/elfxx-x86.c b/bfd/elfxx-x86.c
+index d8c653a9ad2..140e86888a6 100644
+--- a/bfd/elfxx-x86.c
++++ b/bfd/elfxx-x86.c
+@@ -2456,6 +2456,8 @@ _bfd_x86_elf_late_size_sections (bfd *output_bfd,
+ 
+   if (htab->elf.sgotplt)
+     {
++      asection *eh_frame;
++
+       /* Don't allocate .got.plt section if there are no GOT nor PLT
+ 	 entries and there is no reference to _GLOBAL_OFFSET_TABLE_.  */
+       if ((htab->elf.hgot == NULL
+@@ -2468,7 +2470,11 @@ _bfd_x86_elf_late_size_sections (bfd *output_bfd,
+ 	  && (htab->elf.iplt == NULL
+ 	      || htab->elf.iplt->size == 0)
+ 	  && (htab->elf.igotplt == NULL
+-	      || htab->elf.igotplt->size == 0))
++	      || htab->elf.igotplt->size == 0)
++	  && (!htab->elf.dynamic_sections_created
++	      || (eh_frame = bfd_get_section_by_name (output_bfd,
++						      ".eh_frame")) == NULL
++	      || eh_frame->rawsize == 0))
+ 	{
+ 	  htab->elf.sgotplt->size = 0;
+ 	  /* Solaris requires to keep _GLOBAL_OFFSET_TABLE_ even if it
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11495.patch
+++ b/debian/patches/CVE-2025-11495.patch
@@ -1,0 +1,152 @@
+From 6b21c8b2ecfef5c95142cbc2c32f185cb1c26ab0 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 30 Sep 2025 08:18:29 +0800
+Subject: [PATCH] x86: Disallow TLS relocation in non executable section
+
+Since TLS relocations are applied to executable machine instructions,
+disallow TLS relocation in non-SHT_PROGBITS, non-SHF_EXECINSTR section.
+
+	PR ld/33451
+	PR ld/33502
+	* elf32-i386.c (elf_i386_tls_transition): Disallow TLS relocation
+	in non-SHT_PROGBITS, non-SHF_EXECINSTR section.
+	(elf_i386_scan_relocs): Likewise.
+	* elf64-x86-64.c (elf_x86_64_tls_transition): Likewise.
+	(elf_x86_64_scan_relocs): Likewise.
+	* elfxx-x86.c (_bfd_x86_elf_link_report_tls_invalid_section_error):
+	New.
+	* elfxx-x86.h (_bfd_x86_elf_link_report_tls_invalid_section_error):
+	Likewise.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elf32-i386.c   | 19 +++++++++++++++++++
+ bfd/elf64-x86-64.c | 20 ++++++++++++++++++++
+ bfd/elfxx-x86.c    | 20 ++++++++++++++++++++
+ bfd/elfxx-x86.h    |  4 ++++
+ 4 files changed, 63 insertions(+)
+
+diff --git a/bfd/elf32-i386.c b/bfd/elf32-i386.c
+index 507a0762aff..0d60eded701 100644
+--- a/bfd/elf32-i386.c
++++ b/bfd/elf32-i386.c
+@@ -1166,6 +1166,15 @@ elf_i386_tls_transition (struct bfd_link_info *info, bfd *abfd,
+       return true;
+     }
+ 
++  if ((elf_section_type (sec) != SHT_PROGBITS
++       || (sec->flags & SEC_CODE) == 0))
++    {
++      reloc_howto_type *howto = elf_i386_rtype_to_howto (from_type);
++      _bfd_x86_elf_link_report_tls_invalid_section_error
++	(abfd, sec, symtab_hdr, h, sym, howto);
++      return false;
++    }
++
+   /* Return TRUE if there is no transition.  */
+   if (from_type == to_type)
+     return true;
+@@ -1733,6 +1742,16 @@ elf_i386_scan_relocs (bfd *abfd,
+ 		tls_type = GOT_TLS_IE_POS; break;
+ 	      }
+ 
++	    if (tls_type >= GOT_TLS_GD
++		&& tls_type <= GOT_TLS_GDESC
++		&& (elf_section_type (sec) != SHT_PROGBITS
++		    || (sec->flags & SEC_CODE) == 0))
++	      {
++		_bfd_x86_elf_link_report_tls_invalid_section_error
++		  (abfd, sec, symtab_hdr, h, isym, howto);
++		goto error_return;
++	      }
++
+ 	    if (h != NULL)
+ 	      {
+ 		h->got.refcount = 1;
+diff --git a/bfd/elf64-x86-64.c b/bfd/elf64-x86-64.c
+index 620b6a380cd..59b43149897 100644
+--- a/bfd/elf64-x86-64.c
++++ b/bfd/elf64-x86-64.c
+@@ -1626,6 +1626,16 @@ elf_x86_64_tls_transition (struct bfd_link_info *info, bfd *abfd,
+       return true;
+     }
+ 
++  if ((elf_section_type (sec) != SHT_PROGBITS
++       || (sec->flags & SEC_CODE) == 0))
++    {
++      reloc_howto_type *howto = elf_x86_64_rtype_to_howto (abfd,
++							   from_type);
++      _bfd_x86_elf_link_report_tls_invalid_section_error
++	(abfd, sec, symtab_hdr, h, sym, howto);
++      return false;
++    }
++
+   /* Return TRUE if there is no transition.  */
+   if (from_type == to_type
+       || (from_type == R_X86_64_CODE_4_GOTTPOFF
+@@ -2757,6 +2767,16 @@ need_got:
+ 		break;
+ 	      }
+ 
++	    if (tls_type >= GOT_TLS_GD
++		&& tls_type <= GOT_TLS_GDESC
++		&& (elf_section_type (sec) != SHT_PROGBITS
++		    || (sec->flags & SEC_CODE) == 0))
++	      {
++		_bfd_x86_elf_link_report_tls_invalid_section_error
++		  (abfd, sec, symtab_hdr, h, isym, howto);
++		goto error_return;
++	      }
++
+ 	    if (h != NULL)
+ 	      {
+ 		h->got.refcount = 1;
+diff --git a/bfd/elfxx-x86.c b/bfd/elfxx-x86.c
+index 0d389968c91..d8c653a9ad2 100644
+--- a/bfd/elfxx-x86.c
++++ b/bfd/elfxx-x86.c
+@@ -3365,6 +3365,26 @@ _bfd_x86_elf_link_report_tls_transition_error
+   bfd_set_error (bfd_error_bad_value);
+ }
+ 
++/* Report TLS invalid section error.  */
++
++void
++_bfd_x86_elf_link_report_tls_invalid_section_error
++  (bfd *abfd, asection *sec, Elf_Internal_Shdr *symtab_hdr,
++   struct elf_link_hash_entry *h, Elf_Internal_Sym *sym,
++   reloc_howto_type *howto)
++{
++  const char *name;
++  if (h)
++    name = h->root.root.string;
++  else
++    name = bfd_elf_sym_name (abfd, symtab_hdr, sym, NULL);
++  _bfd_error_handler
++    /* xgettext:c-format */
++    (_("%pB: relocation %s against thread local symbol `%s' in "
++       "invalid section `%pA'"), abfd, howto->name, name, sec);
++  bfd_set_error (bfd_error_bad_value);
++}
++
+ /* Return TRUE if symbol should be hashed in the `.gnu.hash' section.  */
+ 
+ bool
+diff --git a/bfd/elfxx-x86.h b/bfd/elfxx-x86.h
+index 1ebc9d2f2e5..f8a24a77577 100644
+--- a/bfd/elfxx-x86.h
++++ b/bfd/elfxx-x86.h
+@@ -951,6 +951,10 @@ extern void _bfd_x86_elf_link_report_tls_transition_error
+    const Elf_Internal_Rela *, const char *, const char *,
+    enum elf_x86_tls_error_type);
+ 
++extern void _bfd_x86_elf_link_report_tls_invalid_section_error
++  (bfd *, asection *, Elf_Internal_Shdr *, struct elf_link_hash_entry *,
++   Elf_Internal_Sym *, reloc_howto_type *);
++
+ #define bfd_elf64_mkobject \
+   _bfd_x86_elf_mkobject
+ #define bfd_elf32_mkobject \
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11839.patch
+++ b/debian/patches/CVE-2025-11839.patch
@@ -1,0 +1,27 @@
+From 12ef7d5b7b02d0023db645d86eb9d0797bc747fe Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Mon, 3 Nov 2025 11:49:02 +0000
+Subject: [PATCH] Remove call to abort in the DGB debug format printing code,
+ thus allowing the display of a fuzzed input file to complete without
+ triggering an abort.
+
+PR 33448
+---
+ binutils/prdbg.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/binutils/prdbg.c b/binutils/prdbg.c
+index c239aeb1a79..5d405c48e3d 100644
+--- a/binutils/prdbg.c
++++ b/binutils/prdbg.c
+@@ -2449,7 +2449,6 @@ tg_tag_type (void *p, const char *name, unsigned int id,
+       t = "union class ";
+       break;
+     default:
+-      abort ();
+       return false;
+     }
+ 
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11840.patch
+++ b/debian/patches/CVE-2025-11840.patch
@@ -1,0 +1,32 @@
+From f6b0f53a36820da91eadfa9f466c22f92e4256e0 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Mon, 3 Nov 2025 09:03:37 +1030
+Subject: [PATCH] PR 33455 SEGV in vfinfo at ldmisc.c:527
+
+A reloc howto set up with EMPTY_HOWTO has a NULL name.  More than one
+place emitting diagnostics assumes a reloc howto won't have a NULL
+name.
+
+	PR 33455
+	* coffcode.h (coff_slurp_reloc_table): Don't allow a howto with
+	a NULL name.
+---
+ bfd/coffcode.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bfd/coffcode.h b/bfd/coffcode.h
+index 1e5acc0032c..ce1e39131b4 100644
+--- a/bfd/coffcode.h
++++ b/bfd/coffcode.h
+@@ -5345,7 +5345,7 @@ coff_slurp_reloc_table (bfd * abfd, sec_ptr asect, asymbol ** symbols)
+       RTYPE2HOWTO (cache_ptr, &dst);
+ #endif	/* RELOC_PROCESSING */
+ 
+-      if (cache_ptr->howto == NULL)
++      if (cache_ptr->howto == NULL || cache_ptr->howto->name == NULL)
+ 	{
+ 	  _bfd_error_handler
+ 	    /* xgettext:c-format */
+-- 
+2.43.7
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -204,3 +204,9 @@ CVE-2025-8225.patch
 0016-LoongArch-Fix-incorrect-display-of-FDEs-address-rang.patch
 0017-LoongArch-Use-more-appropriate-assertions-for-the-re.patch
 0018-LoongArch-set-PRSTATUS_SIZE-0x1e0-to-match-kernel-s-.patch
+CVE-2025-11082.patch
+CVE-2025-11412.patch
+CVE-2025-11494.patch
+CVE-2025-11495.patch
+CVE-2025-11839.patch
+CVE-2025-11840.patch


### PR DESCRIPTION
Backport upstream security fixes for 6 CVEs to binutils 2.41:
- CVE-2025-11082: elf: Don't read beyond .eh_frame section size Upstream fix: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=ea1a0737c7692737a644af0486b71e4a392cbca8
- CVE-2025-11412: PR 33452 SEGV in bfd_elf_gc_record_vtentry Upstream fix: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=047435dd988a3975d40c6626a8f739a0b2e154bc
- CVE-2025-11494: x86: Keep _GLOBAL_OFFSET_TABLE_ for .eh_frame Upstream fix: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=b6ac5a8a5b82f0ae6a4642c8d7149b325f4cc60a
- CVE-2025-11495: x86: Disallow TLS relocation in non executable section Upstream fix: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=6b21c8b2ecfef5c95142cbc2c32f185cb1c26ab0
- CVE-2025-11839: Remove call to abort in DGB debug format printing Bugzilla: https://sourceware.org/bugzilla/show_bug.cgi?id=33448
- CVE-2025-11840: PR 33455 SEGV in vfinfo at ldmisc.c Bugzilla: https://sourceware.org/bugzilla/show_bug.cgi?id=33455

Log: Backport 6 upstream security fixes for binutils CVEs

Influence:
1. Test binutils compilation after applying patches
2. Verify ELF handling with patched .eh_frame logic
3. Validate x86 relocation behavior with new TLS checks
4. Check ldmisc.c vfinfo function with debug format inputs
5. Ensure no regression on loongarch64 and other architectures

fix: 修复 binutils 多个 CVE 漏洞

为 binutils 2.41 回移植上游安全修复，修复 6 个 CVE：
- CVE-2025-11082: elf: 不要读取超出 .eh_frame 段大小的内容
- CVE-2025-11412: PR 33452 bfd_elf_gc_record_vtentry 段错误
- CVE-2025-11494: x86: 为 .eh_frame 保留 _GLOBAL_OFFSET_TABLE_
- CVE-2025-11495: x86: 禁止在非可执行段中使用 TLS 重定位
- CVE-2025-11839: 移除 DGB 调试格式打印中的 abort 调用
- CVE-2025-11840: PR 33455 ldmisc.c 中 vfinfo 段错误

Log: 回移植 6 个上游安全修复以修复 binutils CVE 漏洞

Influence:
1. 测试应用补丁后的 binutils 编译
2. 验证修复后的 ELF .eh_frame 处理逻辑
3. 验证新增 TLS 检查后的 x86 重定位行为
4. 使用调试格式输入检查 ldmisc.c vfinfo 函数
5. 确保 loongarch64 及其他架构无回归

repo: binutils #master