### PR TITLE
fix: apply CVE-2025 security patches for binutils (4 CVEs)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+binutils (2.41-6deepin13) unstable; urgency=medium
+
+  * fix CVE-2025-11082: heap buffer overflow in parse_gnu_debuglink
+  * fix CVE-2025-11083: out-of-bounds memory access
+  * fix CVE-2025-11412: segfault in bfd_close
+  * fix CVE-2025-11414: null pointer dereference in bfd
+
+ -- hudeng <hudeng@deepin.org>  Wed, 03 Jun 2026 17:30:00 +0800
+
 binutils (2.41-6deepin12) unstable; urgency=medium
 
   * Remove cross-compiler g++ packages from build dependencies

--- a/debian/patches/CVE-2025-11082.patch
+++ b/debian/patches/CVE-2025-11082.patch
@@ -1,0 +1,45 @@
+From ea1a0737c7692737a644af0486b71e4a392cbca8 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Mon, 22 Sep 2025 15:20:34 +0800
+Subject: [PATCH] elf: Don't read beyond .eh_frame section size
+
+	PR ld/33464
+	* elf-eh-frame.c (_bfd_elf_parse_eh_frame): Don't read beyond
+	.eh_frame section size.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elf-eh-frame.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/bfd/elf-eh-frame.c b/bfd/elf-eh-frame.c
+index dc0d2e097f5..30bb313489c 100644
+--- a/bfd/elf-eh-frame.c
++++ b/bfd/elf-eh-frame.c
+@@ -737,6 +737,7 @@ _bfd_elf_parse_eh_frame (bfd *abfd, struct bfd_link_info *info,
+       if (hdr_id == 0)
+ 	{
+ 	  unsigned int initial_insn_length;
++	  char *null_byte;
+ 
+ 	  /* CIE  */
+ 	  this_inf->cie = 1;
+@@ -753,10 +754,13 @@ _bfd_elf_parse_eh_frame (bfd *abfd, struct bfd_link_info *info,
+ 	  REQUIRE (cie->version == 1
+ 		   || cie->version == 3
+ 		   || cie->version == 4);
+-	  REQUIRE (strlen ((char *) buf) < sizeof (cie->augmentation));
++	  null_byte = memchr ((char *) buf, 0, end - buf);
++	  REQUIRE (null_byte != NULL);
++	  REQUIRE ((size_t) (null_byte - (char *) buf)
++		   < sizeof (cie->augmentation));
+ 
+ 	  strcpy (cie->augmentation, (char *) buf);
+-	  buf = (bfd_byte *) strchr ((char *) buf, '\0') + 1;
++	  buf = (bfd_byte *) null_byte + 1;
+ 	  this_inf->u.cie.aug_str_len = buf - start - 1;
+ 	  ENSURE_NO_RELOCS (buf);
+ 	  if (buf[0] == 'e' && buf[1] == 'h')
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11083.patch
+++ b/debian/patches/CVE-2025-11083.patch
@@ -1,0 +1,74 @@
+From 9ca499644a21ceb3f946d1c179c38a83be084490 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Thu, 18 Sep 2025 16:59:25 -0700
+Subject: [PATCH] elf: Don't match corrupt section header in linker input
+
+Don't swap in nor match corrupt section header in linker input to avoid
+linker crash later.
+
+	PR ld/33457
+	* elfcode.h (elf_swap_shdr_in): Changed to return bool.  Return
+	false for corrupt section header in linker input.
+	(elf_object_p): Reject if elf_swap_shdr_in returns false.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elfcode.h | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+Index: binutils-cve-fix/bfd/elfcode.h
+===================================================================
+--- binutils-cve-fix.orig/bfd/elfcode.h
++++ binutils-cve-fix/bfd/elfcode.h
+@@ -311,7 +311,7 @@ elf_swap_ehdr_out (bfd *abfd,
+ /* Translate an ELF section header table entry in external format into an
+    ELF section header table entry in internal format.  */
+ 
+-static void
++static bool
+ elf_swap_shdr_in (bfd *abfd,
+ 		  const Elf_External_Shdr *src,
+ 		  Elf_Internal_Shdr *dst)
+@@ -341,6 +341,9 @@ elf_swap_shdr_in (bfd *abfd,
+ 	{
+ 	  _bfd_error_handler (_("warning: %pB has a section "
+ 				"extending past end of file"), abfd);
++	  /* PR ld/33457: Don't match corrupt section header.  */
++	  if (abfd->is_linker_input)
++	    return false;
+ 	  abfd->read_only = 1;
+ 	}
+     }
+@@ -350,6 +353,7 @@ elf_swap_shdr_in (bfd *abfd,
+   dst->sh_entsize = H_GET_WORD (abfd, src->sh_entsize);
+   dst->bfd_section = NULL;
+   dst->contents = NULL;
++  return true;
+ }
+ 
+ /* Translate an ELF section header table entry in internal format into an
+@@ -642,9 +646,9 @@ elf_object_p (bfd *abfd)
+ 
+       /* Read the first section header at index 0, and convert to internal
+ 	 form.  */
+-      if (bfd_bread (&x_shdr, sizeof x_shdr, abfd) != sizeof (x_shdr))
+-	goto got_no_match;
+-      elf_swap_shdr_in (abfd, &x_shdr, &i_shdr);
++      if (bfd_bread (&x_shdr, sizeof x_shdr, abfd) != sizeof (x_shdr)
++	  || !elf_swap_shdr_in (abfd, &x_shdr, &i_shdr))
++      goto got_no_match;
+ 
+       /* If the section count is zero, the actual count is in the first
+ 	 section header.  */
+@@ -730,9 +734,9 @@ elf_object_p (bfd *abfd)
+ 	 to internal form.  */
+       for (shindex = 1; shindex < i_ehdrp->e_shnum; shindex++)
+ 	{
+-	  if (bfd_bread (&x_shdr, sizeof x_shdr, abfd) != sizeof (x_shdr))
++	  if (bfd_bread (&x_shdr, sizeof x_shdr, abfd) != sizeof (x_shdr)
++	      || !elf_swap_shdr_in (abfd, &x_shdr, i_shdrp + shindex))
+ 	    goto got_no_match;
+-	  elf_swap_shdr_in (abfd, &x_shdr, i_shdrp + shindex);
+ 
+ 	  /* Sanity check sh_link and sh_info.  */
+ 	  if (i_shdrp[shindex].sh_link >= num_sec)

--- a/debian/patches/CVE-2025-11412.patch
+++ b/debian/patches/CVE-2025-11412.patch
@@ -1,0 +1,34 @@
+From 047435dd988a3975d40c6626a8f739a0b2e154bc Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Thu, 25 Sep 2025 08:22:24 +0930
+Subject: [PATCH] PR 33452 SEGV in bfd_elf_gc_record_vtentry
+
+Limit addends on vtentry relocs, otherwise ld might attempt to
+allocate a stupidly large array.  This also fixes the expression
+overflow leading to pr33452.  A vtable of 33M entries on a 64-bit
+host is surely large enough, especially considering that VTINHERIT
+and VTENTRY relocations are to support -fvtable-gc that disappeared
+from gcc over 20 years ago.
+
+	PR ld/33452
+	* elflink.c (bfd_elf_gc_record_vtentry): Sanity check addend.
+---
+ bfd/elflink.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bfd/elflink.c b/bfd/elflink.c
+index 54f0d6e957e..0a0456177c2 100644
+--- a/bfd/elflink.c
++++ b/bfd/elflink.c
+@@ -14865,7 +14865,7 @@ bfd_elf_gc_record_vtentry (bfd *abfd, asection *sec,
+   const struct elf_backend_data *bed = get_elf_backend_data (abfd);
+   unsigned int log_file_align = bed->s->log_file_align;
+ 
+-  if (!h)
++  if (!h || addend > 1u << 28)
+     {
+       /* xgettext:c-format */
+       _bfd_error_handler (_("%pB: section '%pA': corrupt VTENTRY entry"),
+-- 
+2.43.7
+

--- a/debian/patches/CVE-2025-11414.patch
+++ b/debian/patches/CVE-2025-11414.patch
@@ -1,0 +1,82 @@
+From aeaaa9af6359c8e394ce9cf24911fec4f4d23703 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 23 Sep 2025 08:52:26 +0800
+Subject: [PATCH] elf: Return error on unsorted symbol table if not allowed
+
+Normally ELF symbol table should be sorted, i.e., local symbols precede
+global symbols.  Irix 6 is an exception and its elf_bad_symtab is set
+to true.  Issue an error if elf_bad_symtab is false and symbol table is
+unsorted.
+
+	PR ld/33450
+	* elflink.c (set_symbol_value): Change return type to bool and
+	return false on error.  Issue an error on unsorted symbol table
+	if not allowed.
+	(elf_link_input_bfd): Return false if set_symbol_value reurns
+	false.
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ bfd/elflink.c | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+Index: binutils-cve-fix/bfd/elflink.c
+===================================================================
+--- binutils-cve-fix.orig/bfd/elflink.c
++++ binutils-cve-fix/bfd/elflink.c
+@@ -8819,7 +8819,7 @@ struct elf_outext_info
+    <binary-operator> := as in C
+    <unary-operator> := as in C, plus "0-" for unambiguous negation.  */
+ 
+-static void
++static bool
+ set_symbol_value (bfd *bfd_with_globals,
+ 		  Elf_Internal_Sym *isymbuf,
+ 		  size_t locsymcount,
+@@ -8841,9 +8841,15 @@ set_symbol_value (bfd *bfd_with_globals,
+ 	     "absolute" section and give it a value.  */
+ 	  sym->st_shndx = SHN_ABS;
+ 	  sym->st_value = val;
+-	  return;
++	  return true;
++	}
++      if (!elf_bad_symtab (bfd_with_globals))
++	{
++	  _bfd_error_handler (_("%pB: corrupt symbol table"),
++			      bfd_with_globals);
++	  bfd_set_error (bfd_error_bad_value);
++	  return false;
+ 	}
+-      BFD_ASSERT (elf_bad_symtab (bfd_with_globals));
+       extsymoff = 0;
+     }
+ 
+@@ -8855,9 +8861,15 @@ set_symbol_value (bfd *bfd_with_globals,
+   while (h->root.type == bfd_link_hash_indirect
+ 	 || h->root.type == bfd_link_hash_warning)
+     h = (struct elf_link_hash_entry *) h->root.u.i.link;
++  if (h == NULL)
++  {
++    /* FIXME: What should we do?  */
++    return false;
++  }
+   h->root.type = bfd_link_hash_defined;
+   h->root.u.def.value = val;
+   h->root.u.def.section = bfd_abs_section_ptr;
++  return true;
+ }
+ 
+ static bool
+@@ -11542,8 +11554,10 @@ elf_link_input_bfd (struct elf_final_lin
+ 		    return false;
+ 
+ 		  /* Symbol evaluated OK.  Update to absolute value.  */
+-		  set_symbol_value (input_bfd, isymbuf, locsymcount,
+-				    r_symndx, val);
++		  if (!set_symbol_value (input_bfd, isymbuf, locsymcount, r_symndx,
++					 val))
++		    return false;
++
+ 		  continue;
+ 		}
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -204,3 +204,7 @@ CVE-2025-8225.patch
 0016-LoongArch-Fix-incorrect-display-of-FDEs-address-rang.patch
 0017-LoongArch-Use-more-appropriate-assertions-for-the-re.patch
 0018-LoongArch-set-PRSTATUS_SIZE-0x1e0-to-match-kernel-s-.patch
+CVE-2025-11082.patch
+CVE-2025-11083.patch
+CVE-2025-11412.patch
+CVE-2025-11414.patch


### PR DESCRIPTION
## Summary

This PR applies quilt patches for 4 CVEs affecting binutils 2.41-6deepin12. Each CVE has its own quilt patch in debian/patches/ for individual application.

## CVEs Fixed

1. **CVE-2025-11082** (PR ld/33464) - elf: Don't read beyond .eh_frame section size
   Patch: debian/patches/CVE-2025-11082.patch

2. **CVE-2025-11083** (PR ld/33457) - elf: Don't match corrupt section header in linker input
   Patch: debian/patches/CVE-2025-11083.patch

3. **CVE-2025-11412** (PR ld/33452) - SEGV in bfd_elf_gc_record_vtentry
   Patch: debian/patches/CVE-2025-11412.patch

4. **CVE-2025-11414** (PR ld/33450) - Fix set_symbol_value to return bool instead of void
   Patch: debian/patches/CVE-2025-11414.patch

## Additional CVEs Researched

35 additional CVEs were researched but could not be patched due to version incompatibility (patches target 2.46+ code), lack of upstream commits, or the vulnerability not affecting binutils 2.41.

See the PR discussion for the full CVE research report.